### PR TITLE
[codex] add tray clipboard reader action

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Reads your clipboard aloud with [**Kokoro-82M**](https://github.com/hexgrad/koko
 
 | Feature | Description |
 |---|---|
-| **Global Hotkey** | Select text anywhere → press `Win+Shift+Q` (or `Cmd+Shift+Q`) → hear it read aloud |
+| **Global Hotkey** | Select text anywhere → press `Win+Shift+Q` on Windows or `Control+Option+R` on macOS → hear it read aloud |
 | **Floating Reader** | A minimal, always-on-top widget appears near your cursor with Play/Pause, Stop, and Speed controls |
 | **Speed Control** | Click or scroll-wheel to cycle: 0.5× → 0.75× → 1× → 1.25× → 1.5× → 1.75× → 2× |
 | **28 Voice Presets** | Choose from Kokoro's full voice library (default: Fenrir) |
-| **System Tray** | Runs headless — lives in your tray/menu bar, never clutters your taskbar |
+| **System Tray** | Runs headless — choose **Read Clipboard** from the tray/menu-bar menu as an alternative to the hotkey |
 | **Auto-Updater** | Silently checks for updates on launch and offers one-click install |
 | **100% Local** | No cloud APIs. No data leaves your machine. Zero latency. |
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,6 +176,8 @@ async fn hide_reader_window(app: AppHandle) -> Result<(), String> {
 
 
 fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
+    let read_clipboard_item =
+        MenuItem::with_id(app, "read_clipboard", "Read Clipboard", true, None::<&str>)?;
     let settings_item = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
     let updates_item =
         MenuItem::with_id(app, "check_updates", "Check for Updates", true, None::<&str>)?;
@@ -184,15 +186,33 @@ fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
 
     let menu = Menu::with_items(
         app,
-        &[&settings_item, &updates_item, &tutorial_item, &quit_item],
+        &[
+            &read_clipboard_item,
+            &settings_item,
+            &updates_item,
+            &tutorial_item,
+            &quit_item,
+        ],
     )?;
 
-    let tray = tauri::tray::TrayIconBuilder::with_id("main-tray")
+    let tray_builder = tauri::tray::TrayIconBuilder::with_id("main-tray")
         .icon(app.default_window_icon().unwrap().clone())
         .menu(&menu)
-        .show_menu_on_left_click(false)
-        .tooltip("Kokoro Clipboard TTS")
+        .tooltip("Kokoro Clipboard TTS");
+
+    #[cfg(target_os = "macos")]
+    let tray_builder = tray_builder
+        .icon_as_template(true)
+        .show_menu_on_left_click(true);
+
+    #[cfg(not(target_os = "macos"))]
+    let tray_builder = tray_builder.show_menu_on_left_click(false);
+
+    let tray = tray_builder
         .on_menu_event(move |app, event| match event.id.as_ref() {
+            "read_clipboard" => {
+                let _ = app.emit("shortcut-triggered", ());
+            }
             "settings" => {
                 if let Some(win) = app.get_webview_window("settings") {
                     let _ = win.show();
@@ -311,6 +331,9 @@ pub fn run() {
 
             // ── Register default global shortcut ──
             use tauri_plugin_global_shortcut::GlobalShortcutExt;
+            #[cfg(target_os = "macos")]
+            let shortcut = "control+option+r";
+            #[cfg(not(target_os = "macos"))]
             let shortcut = "super+shift+q";
             let handle_for_shortcut = handle.clone();
             app.handle().plugin(

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { load } from "@tauri-apps/plugin-store";
 import { register, unregister, isRegistered } from "@tauri-apps/plugin-global-shortcut";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
 
@@ -16,7 +17,7 @@ const VOICE_PRESETS = [
 
 const DEFAULT_VOICE = "am_fenrir";
 const DEFAULT_SHORTCUT_WIN = "Super+Shift+Q";
-const DEFAULT_SHORTCUT_MAC = "Command+Shift+Q";
+const DEFAULT_SHORTCUT_MAC = "Control+Option+R";
 
 function getPlatformDefault() {
   return navigator.userAgent.includes("Mac")
@@ -91,7 +92,7 @@ export default function SettingsWindow() {
       if (shortcutEnabled) {
         await register(shortcut, (event) => {
           if (event.state === "Pressed") {
-            console.log("[Kokoro] Shortcut triggered");
+            void emit("shortcut-triggered");
           }
         });
       }
@@ -110,7 +111,7 @@ export default function SettingsWindow() {
     const parts: string[] = [];
     if (e.metaKey) parts.push("Command");
     if (e.ctrlKey) parts.push("Control");
-    if (e.altKey) parts.push("Alt");
+    if (e.altKey) parts.push(navigator.userAgent.includes("Mac") ? "Option" : "Alt");
     if (e.shiftKey) parts.push("Shift");
     const key = e.key;
     if (!["Control", "Shift", "Alt", "Meta"].includes(key)) {

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -19,7 +19,7 @@ export default function Tutorial() {
   };
 
   const isMac = navigator.userAgent.includes("Mac");
-  const shortcutKey = isMac ? "⌘ + Shift + Q" : "Win + Shift + Q";
+  const shortcutKey = isMac ? "Control + Option + R" : "Win + Shift + Q";
 
   return (
     <div className="window-wrapper" data-tauri-drag-region>
@@ -70,6 +70,7 @@ export default function Tutorial() {
                   <kbd className="px-2.5 py-0.5 rounded-lg bg-white/5 text-white/50 font-mono text-xs border border-white/5 ml-1">
                     {shortcutKey}
                   </kbd>
+                  {" "}or choose Read Clipboard from the tray menu.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## What changed

- adds a **Read Clipboard** action to the system tray/menu-bar menu on Windows and macOS
- routes the tray action through the same `shortcut-triggered` event used by the global hotkey
- changes the unsafe macOS default from `Command+Shift+Q` (reserved for Log Out) to `Control+Option+R`
- makes the macOS menu-bar icon use template rendering and open on normal left-click
- fixes custom shortcuts saved in Settings so they trigger the reader instead of only logging
- updates the tutorial and README

## Impact

Users can invoke clipboard reading without remembering a keyboard shortcut, and macOS users no longer conflict with a system logout shortcut. Windows retains `Win+Shift+Q` and right-click tray behavior.

## Validation

- `npm ci`
- `npm test` — 21 tests passed
- `npm run build`
- `cargo check`
- `git diff --check`