### PR TITLE
fix: sign macOS sidecar for PyInstaller runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,13 @@ jobs:
           # Use platform-specific separator for --add-data
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             SEP=";"
+            CODESIGN_ARGS=()
           else
             SEP=":"
+            CODESIGN_ARGS=(--codesign-identity - --osx-entitlements-file src-tauri/sidecar.entitlements.plist)
           fi
           pyinstaller --onefile --name kokoro \
+            "${CODESIGN_ARGS[@]}" \
             --add-data "sidecar/model${SEP}model" \
             --collect-all onnxruntime \
             --collect-all kokoro \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/build_local_sidecar.py
+++ b/scripts/build_local_sidecar.py
@@ -69,6 +69,15 @@ def run():
         "--collect-all", "spacy",
         "--collect-all", "en_core_web_sm",
     ]
+    if os.name != 'nt':
+        # macOS validates code signatures when PyInstaller's onefile bootloader
+        # extracts and loads the bundled Python framework. Sign all collected
+        # binaries with the same ad-hoc identity so the bootloader and embedded
+        # framework are allowed to load together after installation.
+        pyinstaller_args.extend([
+            "--codesign-identity", "-",
+            "--osx-entitlements-file", os.path.join("src-tauri", "sidecar.entitlements.plist"),
+        ])
     model_dir = os.path.join("sidecar", "model")
     if (
         os.path.isfile(os.path.join(model_dir, "config.json"))

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.6.0"
+version = "0.6.1"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/sidecar.entitlements.plist
+++ b/src-tauri/sidecar.entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    PyInstaller onefile sidecars extract and dlopen a bundled Python.framework
+    at runtime. With hardened runtime enabled, macOS library validation rejects
+    that framework unless this entitlement is present on the sidecar process.
+  -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -80,6 +80,7 @@
     ],
     "externalBin": ["binaries/kokoro"],
     "macOS": {
+      "entitlements": "sidecar.entitlements.plist",
       "signingIdentity": "-"
     },
     "windows": {


### PR DESCRIPTION
## Summary
- add a macOS sidecar entitlement to disable library validation for PyInstaller onefile runtime loading
- pass that entitlement through both the release workflow and local sidecar build script
- configure Tauri macOS signing to preserve the entitlement during final app bundle signing
- bump release version to 0.6.1

## Validation
- npm test -- --run
- cargo test --manifest-path src-tauri/Cargo.toml
- ruby -ryaml -e YAML.load_file workflow parse check
- rebuilt local PyInstaller sidecar and confirmed extracted Python framework no longer fails loader validation
- built local aarch64 DMG
- mounted DMG, verified sidecar entitlement survived Tauri signing
- codesign --verify --deep --strict on mounted app
- offline /health and /tts smoke tests from mounted DMG sidecar

## Release note
This fixes the v0.6.0 macOS ENGINE ERROR where the packaged sidecar failed to load its extracted Python.framework with a Team ID/library-validation error.