### PR TITLE
fix: package compatible setuptools runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,38 @@ jobs:
             mv dist/kokoro "src-tauri/binaries/kokoro-${{ matrix.target }}"
           fi
 
+      - name: Verify frozen sidecar startup
+        shell: bash
+        run: |
+          if [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            SIDECAR="src-tauri/binaries/kokoro-x86_64-pc-windows-msvc.exe"
+          else
+            SIDECAR="src-tauri/binaries/kokoro-${{ matrix.target }}"
+          fi
+
+          "$SIDECAR" --port 8794 > sidecar-startup.log 2>&1 &
+          SIDECAR_PID=$!
+          cleanup_sidecar() {
+            # PyInstaller --onefile uses a launcher and an extracted child process.
+            # Terminate the child first so neither leaks into subsequent build steps.
+            pkill -TERM -P "$SIDECAR_PID" 2>/dev/null || true
+            kill "$SIDECAR_PID" 2>/dev/null || true
+            wait "$SIDECAR_PID" 2>/dev/null || true
+          }
+          trap cleanup_sidecar EXIT
+
+          for _ in {1..60}; do
+            if curl --fail --silent --max-time 2 http://127.0.0.1:8794/health; then
+              cleanup_sidecar
+              trap - EXIT
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat sidecar-startup.log
+          exit 1
+
       - name: Install frontend dependencies
         run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,7 @@ phonemizer-fork==3.3.2
 language_tags
 espeakng_loader
 huggingface_hub
+# PyInstaller's pkg_resources runtime hook requires the legacy provider API.
+# Setuptools 81 removed it, causing the frozen macOS sidecar to exit at startup.
+setuptools<81
 pyinstaller

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.6.1"
+version = "0.6.2"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- pin setuptools below 81 for the PyInstaller sidecar build
- add a frozen-sidecar startup check to each release build
- bump the release version to 0.6.2

## Root cause

The macOS v0.6.1 sidecar bundled a setuptools release whose `pkg_resources` module no longer provides `NullProvider`. PyInstaller's runtime hook imports that API, so the sidecar exited before opening its health endpoint.

## Validation

- `npm test -- --run`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- verified setuptools 80.9.0 exposes `pkg_resources.NullProvider`
- launched the existing frozen macOS sidecar and received `/health`