### PR TITLE
fix: stage offline model for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,50 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  prepare-model:
+    name: Prepare offline Kokoro model
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Download Kokoro model and voices
+        env:
+          # The Windows runner stalled in hf-xet while downloading this public
+          # model. Use the standard HTTP client and keep concurrency modest.
+          HF_HUB_DISABLE_XET: "1"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python -m pip install --disable-pip-version-check huggingface_hub
+          python - <<'PY'
+          from huggingface_hub import snapshot_download
+
+          snapshot_download(
+              repo_id="hexgrad/Kokoro-82M",
+              local_dir="sidecar/model",
+              allow_patterns=["config.json", "kokoro-v1_0.pth", "voices/*.pt"],
+              max_workers=4,
+          )
+          PY
+          test -f sidecar/model/config.json
+          test -f sidecar/model/kokoro-v1_0.pth
+          test -n "$(find sidecar/model/voices -name '*.pt' -print -quit)"
+
+      - name: Upload offline model bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: kokoro-offline-model
+          path: sidecar/model
+          retention-days: 1
+          # Model weights are already compressed; skip CPU-intensive recompression.
+          compression-level: 0
+
   build:
+    needs: prepare-model
     permissions:
       contents: write
     strategy:
@@ -45,23 +88,23 @@ jobs:
         with:
           targets: ${{ startsWith(matrix.platform, 'macos-') && matrix.target || '' }}
 
+      - name: Download offline model bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: kokoro-offline-model
+          path: sidecar/model
+
+      - name: Verify offline model bundle
+        shell: bash
+        run: |
+          test -f sidecar/model/config.json
+          test -f sidecar/model/kokoro-v1_0.pth
+          test -n "$(find sidecar/model/voices -name '*.pt' -print -quit)"
+
       - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
           python -m spacy download en_core_web_sm
-
-      - name: Download Kokoro model and voices
-        shell: bash
-        run: |
-          python - <<'PY'
-          from huggingface_hub import snapshot_download
-
-          snapshot_download(
-              repo_id="hexgrad/Kokoro-82M",
-              local_dir="sidecar/model",
-              allow_patterns=["config.json", "kokoro-v1_0.pth", "voices/*.pt"],
-          )
-          PY
 
       - name: Build Sidecar with PyInstaller
         shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.6.2"
+version = "0.6.3"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- download the offline Kokoro model once on Linux and pass it to each platform build as a workflow artifact
- disable the Hugging Face Xet transport used by the Windows timeout
- cap model preparation at 20 minutes and verify bundle contents before packaging
- bump the release version to 0.6.3

## Root cause

The Windows v0.6.2 runner spent 87 minutes stalled after downloading one of 56 Hugging Face model files through unauthenticated hf-xet.

## Validation

- `HF_HUB_DISABLE_XET=1` verified active in huggingface_hub
- `npm test -- --run`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- release workflow YAML parsed successfully