### PR TITLE
release: Reader Engine v0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows x64
+            platform: windows-latest
+          - name: macOS Apple Silicon
+            platform: macos-15
+          - name: macOS Intel
+            platform: macos-15-intel
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup MSVC developer environment
+        if: matrix.platform == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build and test native speech-rate DSP
+        run: |
+          python -m pip install --disable-pip-version-check numpy
+          python scripts/build_sonic_dsp.py
+          python -m unittest discover -s sidecar -p "test_*.py"
+          python -m unittest discover -s scripts -p "test_*.py"
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Test and build frontend
+        run: |
+          npm test -- --run
+          npm run build
+
+      - name: Test Rust bridge
+        working-directory: src-tauri
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,13 @@ jobs:
         include:
           - name: Windows x64
             platform: windows-latest
+            sidecar: src-tauri/binaries/kokoro-x86_64-pc-windows-msvc.exe
           - name: macOS Apple Silicon
             platform: macos-15
+            sidecar: src-tauri/binaries/kokoro-aarch64-apple-darwin
           - name: macOS Intel
             platform: macos-15-intel
+            sidecar: src-tauri/binaries/kokoro-x86_64-apple-darwin
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
@@ -61,6 +64,9 @@ jobs:
         run: |
           npm test -- --run
           npm run build
+
+      - name: Prepare Tauri test sidecar placeholder
+        run: python -c "from pathlib import Path; path = Path(r'${{ matrix.sidecar }}'); path.parent.mkdir(parents=True, exist_ok=True); path.touch()"
 
       - name: Test Rust bridge
         working-directory: src-tauri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,10 @@ jobs:
         with:
           targets: ${{ startsWith(matrix.platform, 'macos-') && matrix.target || '' }}
 
+      - name: Setup MSVC developer environment
+        if: matrix.platform == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Download offline model bundle
         uses: actions/download-artifact@v4
         with:
@@ -109,17 +113,22 @@ jobs:
       - name: Build Sidecar with PyInstaller
         shell: bash
         run: |
+          python scripts/build_sonic_dsp.py
+
           # Use platform-specific separator for --add-data
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             SEP=";"
+            SONIC_LIBRARY="sidecar/native/sonic_kctts.dll"
             CODESIGN_ARGS=()
           else
             SEP=":"
+            SONIC_LIBRARY="sidecar/native/libsonic_kctts.dylib"
             CODESIGN_ARGS=(--codesign-identity - --osx-entitlements-file src-tauri/sidecar.entitlements.plist)
           fi
           pyinstaller --onefile --name kokoro \
             "${CODESIGN_ARGS[@]}" \
             --add-data "sidecar/model${SEP}model" \
+            --add-binary "${SONIC_LIBRARY}${SEP}native" \
             --collect-all onnxruntime \
             --collect-all kokoro \
             --collect-all misaki \
@@ -141,6 +150,12 @@ jobs:
           else
             mv dist/kokoro "src-tauri/binaries/kokoro-${{ matrix.target }}"
           fi
+
+      - name: Run Python tests
+        shell: bash
+        run: |
+          python -m unittest discover -s sidecar -p 'test_*.py'
+          python -m unittest discover -s scripts -p 'test_*.py'
 
       - name: Verify frozen sidecar startup
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 src-tauri/binaries/
 sidecar/kokoro.pid
 sidecar/model/
+sidecar/native/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Please check out our **[Contributing Guide](.agent/CONTRIBUTING.md)** for full d
 
 *The React frontend communicates via Tauri with the Rust backend, which securely manages a headless local Python server running the Kokoro TTS engine.*
 
+The Python sidecar is packaged as a standalone executable during release builds, so users do not need to install Python or set up the AI stack manually. It bundles the Kokoro runtime and its supporting libraries, including `torch`, `onnxruntime`, `phonemizer`, `espeak-ng` data, and the model weights/voices used for offline synthesis. That keeps the app fully local while still shipping the native ML dependencies needed to generate speech.
+
 ---
 
 ## 📁 Project Structure

--- a/RELEASE_TESTING.md
+++ b/RELEASE_TESTING.md
@@ -30,36 +30,35 @@ Always ensure your `requirements.txt` precisely matches what your local virtual 
 
 ---
 
-## Step 2: Download Necessary Models Locally (Simulating CI)
-The CI downloads the model to `sidecar/model` before freezing it. You need to do this locally as well before running PyInstaller:
+## Step 2: Download the v1.0 Model (Simulating CI)
+The CI downloads the official Kokoro v1.0 weights and voices to `sidecar/model` before freezing. Use the same pinned file set locally:
 
-**In PowerShell:**
 ```powershell
-New-Item -ItemType Directory -Force -Path sidecar\model
-Invoke-WebRequest -Uri "https://github.com/hexgrad/kokoro/raw/main/kokoro-v0.19.onnx" -OutFile "sidecar\model\kokoro-v0.19.onnx"
-Invoke-WebRequest -Uri "https://github.com/hexgrad/kokoro/raw/main/voices.json" -OutFile "sidecar\model\voices.json"
+python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='hexgrad/Kokoro-82M', local_dir='sidecar/model', allow_patterns=['config.json', 'kokoro-v1_0.pth', 'voices/*.pt'])"
 ```
 
-**In Git Bash:**
-```bash
-mkdir -p sidecar/model
-curl -L -o sidecar/model/kokoro-v0.19.onnx https://github.com/hexgrad/kokoro/raw/main/kokoro-v0.19.onnx
-curl -L -o sidecar/model/voices.json https://github.com/hexgrad/kokoro/raw/main/voices.json
-```
+Verify that `sidecar/model/config.json`, `sidecar/model/kokoro-v1_0.pth`, and at least one file under `sidecar/model/voices/` exist.
 
 ---
 
 ## Step 3: PyInstaller Freeze (Simulating CI)
 From your root repository (make sure your `.sidecar-venv` is activated):
 
+Build the vendored Sonic real-time speed library first:
+
+```powershell
+python scripts/build_sonic_dsp.py
+```
+
 **In PowerShell:**
 ```powershell
 pyinstaller --onefile --name kokoro `
   --add-data "sidecar/model;model" `
+  --add-binary "sidecar/native/sonic_kctts.dll;native" `
   --collect-all onnxruntime `
   --collect-all kokoro `
   --collect-all misaki `
-  --collect-all phonemizer-fork `
+  --collect-all phonemizer `
   --collect-all language_tags `
   --collect-all espeakng_loader `
   --collect-all huggingface_hub `
@@ -68,6 +67,8 @@ pyinstaller --onefile --name kokoro `
   --collect-all torch `
   --collect-all loguru `
   --collect-all transformers `
+  --collect-all spacy `
+  --collect-all en_core_web_sm `
   sidecar/kokoro_server.py
 ```
 
@@ -75,10 +76,11 @@ pyinstaller --onefile --name kokoro `
 ```bash
 pyinstaller --onefile --name kokoro \
   --add-data "sidecar/model;model" \
+  --add-binary "sidecar/native/sonic_kctts.dll;native" \
   --collect-all onnxruntime \
   --collect-all kokoro \
   --collect-all misaki \
-  --collect-all phonemizer-fork \
+  --collect-all phonemizer \
   --collect-all language_tags \
   --collect-all espeakng_loader \
   --collect-all huggingface_hub \
@@ -87,6 +89,8 @@ pyinstaller --onefile --name kokoro \
   --collect-all torch \
   --collect-all loguru \
   --collect-all transformers \
+  --collect-all spacy \
+  --collect-all en_core_web_sm \
   sidecar/kokoro_server.py
 ```
 
@@ -98,7 +102,13 @@ Run your newly built `.exe` from the `dist` folder:
 .\dist\kokoro.exe --port 8791
 ```
 
-Send a test POST request to it from another terminal to ensure it loads everything without crashing:
+Wait for the health endpoint before testing audio. Startup now prewarms both Kokoro and the Sonic speed processor:
+
+```powershell
+Invoke-RestMethod -Uri "http://127.0.0.1:8791/health"
+```
+
+Then send a test-audio request:
 
 **In PowerShell:**
 ```powershell
@@ -109,4 +119,4 @@ Invoke-RestMethod -Uri "http://127.0.0.1:8791/test_audio" -Method POST -Body "{}
 ```bash
 curl -X POST http://127.0.0.1:8791/test_audio -H "Content-Type: application/json" -d "{}"
 ```
-If you hear the beep and see no errors in the console, your frozen sidecar is solid and safe to release!
+The beep is only a packaging smoke test. Before release, also run the Python, frontend, and Rust suites; synthesize the reader corpus; verify a mid-sentence speed change; and complete the manual/soak gates in `ROADMAP.md`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,486 @@
+# Kokoro Clipboard TTS v0.7 Roadmap
+
+Status: v0.7.0 release candidate
+Baseline release: v0.6.3
+Working release name: **Reader Engine**
+
+## Release train
+
+- **v0.7.0 — Reader Engine:** ship the locally validated session controller, exact pause/resume, live pitch-preserved speed, structural clipboard/planner foundation, code-block setting, startup prewarm, and first-audio feedback. Pocket TTS and GPU selection are not included.
+- **v0.8.x — Speech Intelligence:** numbers, dates, URLs, paths, pronunciation dictionary, pause tuning, sentence navigation, and reader profiles.
+- **v0.9.x — Engine Lab:** optional Pocket TTS engine packs, evidence-based GPU/backend selection, package slimming, and broader platform bake-offs.
+- **v1.0 — Stable Reader:** accessibility and upgrade hardening, full supported-platform release matrix, long-session soak evidence, and a frozen public behavior contract.
+
+## Progress ledger
+
+- W0.1 request/session IDs: implemented locally; packaged-app verification pending.
+- W0.2 structured lifecycle timing: implemented through the first successful audio write plus stream-acknowledged pause/resume sample offsets; benchmark result persistence pending.
+- W0.3 reader-quality corpus: initial 24-case v1 corpus implemented.
+- W0.4 benchmark tooling: lifecycle-log analyzer implemented; automated benchmark request runner pending.
+- W0.5 fake audio integration harness: the production queue player runs against fake streams with exact offset, multi-chunk ordering, failed-write, cancellation, 50-thread replacement-race, and 500-chunk bounded-queue coverage; real-time 30-minute soak remains a release gate.
+- W1.0 clipboard structure recovery: a native command reads both plain text and HTML where the source app provides them; matching HTML is converted to local structural hints, mismatches fall back to plain text, and high-confidence plain heading inference is fixture-locked. Cross-app manual verification remains.
+- W1.1–W1.2 structural planner: headings, paragraphs, lists, quotes, code source mapping, bounded sentence/clause segmentation, and segment-specific pauses implemented locally.
+- W1.3 normalization rules: conservative spoken forms for Okay/idk/lol/TBH/imo and stronger informal ellipsis pauses are fixture-locked; numbers, technical text, and user overrides remain pending.
+- W1.5 code behavior: code blocks are always announced, read with identifier/operator normalization by default, and announced as skipped only when the stored setting is enabled; broader code fixtures remain pending.
+- W2.1/W2.8 session controller: per-request cancellation, pause state, chunk/sample position, serialized inference, cancellation-aware queue backpressure, stale-control rejection, and deterministic replacement-race tests implemented locally; live overlap test pending.
+- W2.2 persistent queue player: production playback state machine extracted behind a sounddevice-independent stream contract and covered by integration tests; packaged-device testing pending.
+- W2.3 exact pause/resume: sample-offset retention implemented locally; live and packaged-app acceptance measurements pending.
+- W2.6–W2.7 runtime speed: Apache-2.0 Sonic is vendored behind a small streaming C ABI, applies speed changes between 20 ms source blocks, and is wired through UI, Tauri, session state, playback, local build, and release packaging. Native and signed frozen macOS arm64 startup tests pass; Windows, macOS x64, command-to-audible measurement, and human listening gates remain.
+- W3.1–W3.2 latency path: default engine prewarms before health/ready, the fixed 100 ms request delay is removed, and the 250 ms first-buffer silence is replaced by concurrent output-stream warmup; live clipping check pending.
+- W3.4–W3.6 first-audio feedback: rolling local median keyed by backend, voice, and first-segment-size bucket; low-confidence indeterminate state; conservative 90%-capped bar; and half-second remaining-time label implemented. Playback-remaining estimate is pending.
+- W4.2 backend benchmark: corpus-driven PyTorch CPU/MPS runner and initial M2 reference suite implemented; Windows/CUDA and frozen-package measurements pending.
+- W5.3 Pocket TTS benchmark: isolated v2.1.0 CPU streaming runner and initial M2 unquantized/quantized measurements implemented; blind quality and frozen-package work pending.
+- Remaining W1–W6 work: active, sequenced below; engine promotion remains evidence-gated.
+
+## Release outcome
+
+v0.7 should make reading feel immediate, controllable, and deliberately spoken rather than merely converting a flattened clipboard string into audio.
+
+The release is successful when it:
+
+1. pauses and resumes at the actual playback position;
+2. applies speed changes predictably without replaying text or changing pitch;
+3. preserves useful document structure and handles common shorthand, numbers, and code intentionally;
+4. starts audible playback materially faster and reports honest progress while waiting;
+5. includes a measured experimental acceleration/model path without weakening the stable offline default; and
+6. adds sentence navigation and remaining-time feedback so users can control longer readings.
+
+This roadmap separates model inference, speech planning, and audio playback. That separation is required: changing models alone cannot recover formatting that the app discarded or fix playback state that the app never tracked.
+
+## Product principles
+
+- **Local by default:** clipboard content must remain on the device. No cloud inference or telemetry is part of v0.7.
+- **Stable default, explicit experiments:** experimental engines and compute backends must be opt-in and must fall back safely.
+- **Measure audible latency:** generation completion and first audible sample are different events. Acceptance tests use the latter.
+- **Preserve meaning, not markup:** formatting should become pauses and reading cues rather than being read literally or collapsed indiscriminately.
+- **User correction beats hidden heuristics:** pronunciation and shorthand behavior must be inspectable and overrideable.
+- **Cross-platform packaging is part of the feature:** a backend is not supported until it works in the frozen Windows and macOS applications.
+
+## Aligned product decisions
+
+Confirmed with the product owner on 2026-07-25. Primary-content weighting and final engine promotion still require listening evidence, but implementation semantics are no longer open.
+
+| Decision | Default assumption | Consequence if changed |
+|---|---|---|
+| Primary content | Articles, documentation, AI/chat responses, and email; code is secondary | Changes the weighting of the speech-quality corpus |
+| Clipboard structure | Prefer matching rich clipboard HTML; otherwise preserve plain-text boundaries and infer only high-confidence short headings. Never alter the selected words to invent structure | Requires native HTML clipboard reads plus source-app compatibility tests |
+| Runtime speed semantics | Pitch-preserved changes affect already-playing speech mid-sentence, targeting 150 ms p95; optimize and recommend 0.75x–1.5x, with 0.5x–2.0x treated as an advanced range | Requires a real-time time-stretch DSP path; regeneration at sentence boundaries is insufficient |
+| Code blocks | Always announce code blocks; read them intelligently by default; skip only when the user enables the setting | Requires a stored setting plus concise identifier/operator normalization |
+| Informal shorthand | `idk`, `lol`, `TBH`, and `imo` are pronounced as initialisms for now; later user dictionary rules override built-ins | Changes default lexicon fixtures only |
+| Experimental models | Pocket TTS may be offered as an opt-in on-device engine; Kokoro remains the installed fallback until quality and packaging gates pass | Requires in-app lifecycle/download UX and engine-specific voices/settings |
+| Release numbering | Ship this work as v0.7.0, not v1.0 | A v1.0 designation would require a broader stability/support commitment |
+
+## v0.6.3 baseline evidence
+
+- `src/utils/textCleaner.ts` collapses all whitespace, including paragraph and list boundaries, with `\s+`.
+- `sidecar/kokoro_server.py` tracks pause and stop globally rather than by playback session.
+- Pausing during a chunk restarts that chunk on resume because no sample offset is retained.
+- Changing speed in `FloatingWidget.tsx` updates persisted UI state but sends no command to active playback.
+- The sidecar waits 100 ms before starting a request, prepends 250 ms of silence to the first chunk, and adds 200 ms after every generated chunk.
+- The UI infers playback from sidecar log text rather than receiving structured synthesis/playback events.
+- The official general-purpose Kokoro model remains v1.0. Alternative runtimes use the same weights and therefore do not inherently improve prosody.
+- Local M2 measurements showed that PyTorch MPS and quantized ONNX CPU were slower than the existing PyTorch CPU path. Hardware acceleration cannot be assumed from provider availability.
+- The v0.6.3 baseline had 21 text-cleaner tests and no Rust unit tests. Existing release testing verifies startup and a beep rather than the full reader behavior in this roadmap.
+
+### Initial backend reference measurement
+
+Measured locally on 2026-07-25 using an Apple M2, macOS 14.4, PyTorch 2.11.0, Kokoro 0.9.4, one short warmup, and one pass over four differently sized corpus fixtures. These are diagnostic results, not release acceptance evidence.
+
+| Backend | Ready time | Successful fixtures | First-chunk median | First-chunk p95 | Critical observation |
+|---|---:|---:|---:|---:|---|
+| PyTorch CPU | 2.75 s | 4/4 | 1.36 s | 4.84 s | Reliable, but the 37-word single sentence took 4.84 s |
+| PyTorch MPS | 3.03 s | 3/4 | 0.78 s | 0.86 s among successes | Faster for bounded inputs, but the 37-word sentence failed with the MPS 65,536-output-channel limit |
+
+MPS is therefore not eligible for automatic selection with the unbounded v0.6.3 sentence path. The local structural planner splits the failing 229-character fixture into 136- and 92-character semantic segments, both of which synthesized successfully on MPS. The full suite and frozen package must still pass before MPS is reconsidered for automatic selection.
+
+A second three-repetition CPU diagnostic after adding startup prewarm measured 3.15 s to load the engine and a 2.97 s median across 12 raw-fixture runs (fixture medians 1.60–9.28 s). This is intentionally not presented as an improvement: the runner still sends each raw fixture directly, while the application now sends bounded planned segments. It confirms that startup prewarm moves roughly 3–4 seconds out of the first user request, but end-to-end first-audio acceptance must be measured through the real planned request path and remains open.
+
+## Target architecture
+
+```text
+Clipboard text
+    |
+    v
+Clipboard structure recovery
+  - plain text is the content authority
+  - matching HTML restores headings, paragraphs, lists, and explicit breaks
+  - conservative fallback when formatting is absent or disagrees
+    |
+    v
+Speech planner
+  - preserves source structure
+  - normalizes spoken forms
+  - emits semantic segments and pause intent
+    |
+    v
+Engine adapter
+  - Kokoro stable adapter
+  - experimental Pocket TTS adapter
+  - structured synthesis events and timing
+    |
+    v
+Session audio controller
+  - session ID and cancellation
+  - generated-chunk lookahead/cache
+  - sentence index and sample offset
+  - pitch-preserved playback speed
+    |
+    v
+Tauri event contract -> reader widget
+```
+
+### Planned segment contract
+
+The speech planner should return data rather than one flattened string:
+
+```ts
+type SpeechSegment = {
+  id: string;
+  sourceText: string;
+  spokenText: string;
+  kind: "heading" | "paragraph" | "sentence" | "list-item" | "quote" | "code";
+  pauseAfterMs: number;
+  sourceStart: number;
+  sourceEnd: number;
+};
+```
+
+Exact transport types may change, but source mapping, segment kind, and pause intent are required.
+
+## Workstreams
+
+### W0 — Instrumentation and regression corpus
+
+This work lands first so later performance and quality claims are supported by evidence.
+
+Tasks:
+
+- W0.1 Add request/session IDs to all sidecar events.
+- W0.2 Emit structured timestamps for request received, planning complete, inference start, first chunk ready, first sample written, pause acknowledged, resume acknowledged, and playback finished.
+- W0.3 Create a versioned reader-quality corpus containing prose, chat, formatting, acronyms, numbers, URLs, filenames, and code.
+- W0.4 Add a benchmark runner that records cold start, warm time-to-first-audio, real-time factor, peak memory, and generated duration as JSON.
+- W0.5 Add an audio/control integration harness using a fake output sink so pause position and chunk ordering can be tested without speakers.
+
+Acceptance criteria:
+
+- Every request has one unique ID propagated through UI, Rust, and sidecar events.
+- Old or cancelled requests cannot emit state changes for the active session.
+- Benchmark results record OS, architecture, backend, model, voice, text fixture, and cold/warm state.
+- Timing events are generated from the actual audio write path, not inferred from log strings.
+
+### W1 — Structured speech planner
+
+Tasks:
+
+- W1.0 Read plain and HTML clipboard representations, accept rich structure only when visible words match, and retain a deterministic plain-text fallback.
+- W1.1 Replace destructive whitespace flattening with block-aware parsing.
+- W1.2 Convert headings, paragraphs, lists, quotes, and blank lines into semantic segments and configurable pauses.
+- W1.3 Add deterministic English normalization for common chat shorthand and acronyms.
+- W1.4 Add locale-aware normalization for numbers, currency, time, dates, percentages, units, versions, and long digit strings.
+- W1.5 Always announce code blocks. Read identifiers and operators intelligently by default; when the user enables **Skip code blocks**, announce that the block was skipped instead of reading its contents.
+- W1.6 Add a user pronunciation/replacement dictionary with whole-word and case-sensitive options.
+- W1.7 Preserve source offsets so the UI can show the current sentence later.
+
+Initial pause policy to validate by listening tests:
+
+| Boundary | Initial pause |
+|---|---:|
+| Comma/clause | model-controlled |
+| Sentence | 120 ms external minimum |
+| List item | 220 ms |
+| Paragraph | 420 ms |
+| Heading | 550 ms |
+| Major section/blank-line run | 700 ms maximum |
+
+Acceptance criteria:
+
+- Paragraphs and list items remain distinguishable after planning.
+- HTML-derived structure never changes the selected visible words and falls back to plain text on any mismatch.
+- Copy fixtures from at least one browser, document editor, chat app, and plain-text editor pass on Windows and macOS; the test record identifies which structural formats each source actually supplies.
+- When formatting is absent, inferred headings require conservative evidence and hard-wrapped prose remains unsplit in regression fixtures.
+- Every normalization rule has input/output fixtures, including punctuation and word-boundary counterexamples.
+- User dictionary rules override built-in shorthand rules.
+- Planning is deterministic, offline, and does not log clipboard text in release builds.
+- A blind listening pass rates the planned version equal or better than the v0.6.3 baseline on at least 80% of corpus items, with no critical regressions.
+
+### W2 — Session audio controller and runtime controls
+
+Tasks:
+
+- W2.1 Replace global playback events with a session object containing cancellation, chunk index, and sample offset.
+- W2.2 Use a persistent output stream with bounded block writes and exact offset accounting.
+- W2.3 Implement pause/resume without replay or skip.
+- W2.4 Add sentence back/forward commands and cache recently generated sentence audio.
+- W2.5 Add bounded lookahead generation with backpressure.
+- W2.6 Prototype pitch-preserved time stretching suitable for frozen Windows and macOS builds.
+- W2.7 Apply active speed changes at the agreed boundary and invalidate only stale future audio.
+- W2.8 Make stop/new-request cancellation race-safe.
+
+Acceptance criteria:
+
+- Pause reaches silence within 100 ms at p95.
+- Resume starts within 150 ms at p95 when current audio is cached.
+- Resume position differs by no more than 100 ms and never restarts the sentence.
+- A new request cannot leak audio or completion events from the previous session.
+- Previous/next sentence responds within 150 ms when target audio is cached.
+- Speed changes preserve pitch perceptually and do not create a gap over 250 ms at the agreed transition boundary.
+- Thirty minutes of continuous playback produces no unbounded queue or memory growth.
+
+Decision gate W2-D1:
+
+- Mid-sentence behavior is required. Use Sonic as the production candidate: it is an Apache-2.0 ANSI C streaming library built specifically for pitch-preserving speech-rate control, with no Python-wheel or C++ runtime dependency.
+- A native Apple M2 spike at 24 kHz preserved a 220 Hz test tone within 1 Hz at 0.5x, 0.75x, 1x, 1.5x, and 2x; processed two seconds of input in roughly 0.8–3.6 ms; and reflected a 1x-to-2x change no later than the second 20 ms input block. Synthetic tests validate duration and pitch but do not replace human speech listening.
+- Use approximately 20 ms source buffers so the slowest 0.5x output write remains about 40 ms. The speed endpoint updates session state; the playback DSP reads it between buffers without regeneration, replay, or pitch change.
+- Treat 0.75x–1.5x as the recommended, quality-first range and apply the strictest listening gate there. Keep 0.5x–2.0x available as an advanced range, clearly allowing more artifacts at its extremes.
+- The existing `python-stretch` wrapper is rejected for this path because each `process()` call pads, flushes, and resets the processor; using it buffer-by-buffer is not continuous real-time streaming. Signalsmith's MIT-licensed C++ core remains a fallback only if the project owns a true streaming binding. Reject Rubber Band for the default implementation unless a commercial license is purchased because its open-source distribution is GPL; SoundTouch remains the LGPL fallback.
+
+### W3 — Faster first audio and honest progress
+
+Tasks:
+
+- W3.1 Load and warm the selected default engine during sidecar startup.
+- W3.2 Remove the fixed pre-request delay and replace first-chunk silence with output-stream warmup or a measured minimum.
+- W3.3 Prioritize a short first semantic segment, then generate larger lookahead segments.
+- W3.4 Add rolling device-local estimates keyed by backend, voice, and first-segment size.
+- W3.5 Show preparation, first-audio generation, playback progress, and estimated remaining time in the widget.
+- W3.6 Ensure estimates degrade to indeterminate state when confidence is low rather than displaying false precision.
+- W3.7 Reduce cold app readiness time by auditing broad PyInstaller `collect-all` rules, excluding development/tests and unused backends, and comparing one-file extraction with a signed pre-extracted sidecar layout.
+
+Acceptance criteria on supported reference hardware:
+
+- Warm first-audio median is at most 750 ms and p95 is at most 1.5 seconds for the short-text fixture set, or the release documents an approved hardware-specific exception.
+- Cold-start and warm-start latency are reported separately.
+- Cold installed-app launch reaches a synthesis-ready health state within 10 seconds p95 on the supported reference machines.
+- The progress indicator never reaches zero or 100% before audio is ready.
+- Once at least five comparable local samples exist, first-audio estimates are within the greater of 500 ms or 35% for at least 80% of requests.
+- Playback remaining time updates from generated audio duration and clearly marks estimated pending duration.
+
+### W4 — Experimental compute backends
+
+The feature is backend selection, not a promise that a GPU is faster.
+
+Tasks:
+
+- W4.1 Define `Auto`, `CPU`, and platform-supported experimental providers behind one capability API.
+- W4.2 Benchmark PyTorch CPU/CUDA/MPS and viable ONNX providers on supported packaging targets.
+- W4.3 Make `Auto` choose only from providers that pass a startup, synthesis, and output-equivalence smoke test.
+- W4.4 Fall back to CPU after initialization or inference failure and surface the reason in diagnostics.
+- W4.5 Record package-size, startup-time, memory, and driver/runtime requirements for each provider.
+
+Acceptance criteria:
+
+- Provider selection never prevents the app from starting.
+- `Auto` does not choose a provider slower than CPU by more than 10% on the calibration fixture.
+- An experimental provider must improve either warm first-audio or long-text throughput by at least 20% on a supported hardware class before it is recommended in UI.
+- Frozen Windows and macOS packages pass the same synthesis fixtures as development mode.
+- UI language says “compute backend,” not “GPU boost,” and marks non-default providers experimental.
+
+Decision gate W4-D1:
+
+- Drop a provider from v0.7 if its packaged runtime cost or failure rate outweighs measured benefit. Provider availability alone is not sufficient.
+
+### W5 — Experimental speech-engine bake-off
+
+Candidates:
+
+1. Kokoro v1.0 PyTorch — stable baseline.
+2. Pocket TTS — primary experimental candidate due to CPU streaming and low reported first-audio latency.
+3. Chatterbox Nano — evaluate if packaging and first-audio latency are competitive.
+4. Kitten TTS — evaluate normalization and package size, but treat developer-preview status as a risk.
+
+Qwen3-TTS is excluded from the v0.7 desktop default because its 0.6B/1.7B models and GPU-oriented deployment conflict with the lightweight zero-config target. It can be reconsidered as an optional power-user engine later.
+
+Tasks:
+
+- W5.1 Implement a narrow engine-adapter protocol and keep playback outside model-specific code.
+- W5.2 Produce anonymized, loudness-normalized blind samples for the regression corpus.
+- W5.3 Measure latency, throughput, peak memory, model size, frozen binary size, and supported platforms.
+- W5.4 Score pronunciation, stress, pausing, stability, voice preference, and normalization interaction.
+- W5.5 Ship at most one non-Kokoro experimental engine in v0.7.
+
+Scorecard:
+
+| Dimension | Weight |
+|---|---:|
+| Blind speech preference | 30% |
+| Warm time-to-first-audio | 20% |
+| Pronunciation/prosody corpus pass rate | 15% |
+| Cross-platform frozen-build reliability | 15% |
+| Installer/model download size | 10% |
+| Long-text throughput and memory | 10% |
+
+Promotion requirements:
+
+- An engine must beat Kokoro's weighted score by at least 10% to become the recommended default.
+- A result within 10% remains experimental; Kokoro stays default.
+- Any licensing, offline-operation, or frozen-build failure disqualifies an engine regardless of audio score.
+
+#### Pocket TTS reference measurement
+
+Measured locally on 2026-07-25 using Pocket TTS 2.1.0, Python 3.12.13, and an Apple M2. The unquantized run used one warmup and three passes over the four-fixture latency suite (12 successful runs):
+
+| Variant | Cached engine + voice ready | Successful runs | First streamed frame median | First streamed frame p95 | Median full-generation RTF | Peak process RSS |
+|---|---:|---:|---:|---:|---:|---:|
+| Pocket TTS CPU | 0.80 s | 12/12 | 87 ms | 171 ms | 0.265 | 1.05 GB |
+| Pocket TTS CPU quantized | 0.97 s | 4/4 | 160 ms | 403 ms | 0.568 | 1.12 GB |
+
+The first uncached run took 22.3 seconds to download/load the model and prepare its voice; bundling or explicitly downloading weights removes network time. The cached Hugging Face weight snapshot occupies about 215 MB, and the isolated Python environment occupies about 719 MB before packaging/deduplication. Quantization is not recommended on this M2 because it regressed both latency and throughput without reducing observed peak RSS.
+
+Pocket TTS passes the performance threshold for an experimental adapter by a wide margin, but not the overall promotion gate: blind speech-quality preference, pause/segment continuity, Windows and frozen-macOS packaging, and installer delta are still unmeasured. Its official API streams roughly 80 ms frames; its documented inability to encode requested silence in text means the app's existing structural segment and silence mixer remains necessary. Keep Kokoro as default until those gates pass.
+
+A signed local macOS arm64 Kokoro/Sonic PyInstaller smoke build passed startup and health, but the current broad `collect-all` recipe produced a 525 MB one-file sidecar before the outer app installer. That is a base-runtime packaging problem to address in W3.7, and it strengthens the decision not to merge Pocket's roughly 719 MB isolated environment into every user's base install without a measured, compressed-delta gate.
+
+#### Pocket TTS product and distribution decision
+
+Pocket TTS is a separate 100M-parameter speech model, not “faster Kokoro.” It has different voices and may sound better on some text and worse on other text. It has no per-use monetary cost because inference remains local; “cheaper” means lower waiting/compute time, offset by additional disk and maintenance cost.
+
+For v0.7, use one normal app installer and an in-app optional engine flow rather than separate “Kokoro” and “Pocket” installers or a manual GitHub setup:
+
+1. Settings shows **Kokoro — Stable, Installed** and **Pocket TTS — Experimental, Faster start, ~215 MB model download**.
+2. Pocket is never downloaded automatically. The user explicitly selects Download, sees progress/disk requirements and license/privacy text, and can cancel or remove it.
+3. Pin engine-pack versions and SHA-256 hashes in a signed manifest. Download to a temporary app-data file, verify it, then atomically activate it; resume interrupted downloads when the host permits.
+4. Keep engine-specific voice choices. Switching engines stops the current session, warms the target engine, and falls back to Kokoro with a visible diagnostic if loading or synthesis fails.
+5. Clipboard text never leaves the machine. Network access is only for the user-requested engine asset.
+6. Bundle Pocket's adapter code with the main sidecar only if the compressed installer delta stays below 75 MB. Otherwise ship a signed per-platform engine pack so non-users do not pay the dependency cost.
+7. Publish engine assets for Windows x64, macOS arm64, and macOS x64 through the normal release pipeline. Do not label a platform supported until a frozen binary synthesizes the corpus there.
+8. Do not expose voice cloning in v0.7; it adds consent, impersonation, storage, and support risks unrelated to the reader goal.
+
+GitHub release assets may host the signed model/engine artifacts, but users should install and manage them inside the app. Requiring manual GitHub downloads creates path, version, checksum, and support failures; separate installers fragment updates and confuse which app owns settings.
+
+### W6 — Reader UX and accessibility
+
+Tasks:
+
+- W6.1 Add previous/next sentence controls without making the compact widget materially larger by default.
+- W6.2 Show current sentence position and estimated remaining time in an expandable detail state.
+- W6.3 Add Article, Chat, and Code reading profiles.
+- W6.4 Add settings for code behavior, shorthand defaults, pause strength, and pronunciation replacements.
+- W6.5 Add local “report bad reading” export containing source, planned segments, non-sensitive runtime metadata, and settings only after explicit user action.
+- W6.6 Ensure controls have keyboard access, accessible names, visible focus, and non-color status cues.
+
+Acceptance criteria:
+
+- All playback actions are usable without a mouse.
+- The compact widget retains its current primary play/pause, stop, speed, and close actions.
+- The UI distinguishes preparing, generating, speaking, paused, finished, and error states from structured events.
+- Diagnostic export previews exactly what will be saved and never transmits it.
+
+## Execution order
+
+```text
+Milestone A: Evidence foundation
+  W0 instrumentation + corpus
+
+Milestone B: Reader correctness
+  W1 speech planner
+  W2 session controller, exact pause/resume, sentence navigation
+
+Milestone C: Perceived performance
+  W3 warmup, first-segment priority, progress/ETA
+
+Milestone D: Experiments
+  W4 backend matrix
+  W5 Pocket TTS bake-off
+
+Milestone E: Product integration
+  W6 settings, profiles, accessibility, diagnostics
+
+Milestone F: Release hardening
+  cross-platform frozen builds, soak tests, migration, documentation
+```
+
+W4 and W5 begin only after W0 produces trustworthy measurements. W6 visual work can begin after the W1/W2 event and state contracts stabilize.
+
+## Proposed implementation slices
+
+Each slice should be independently reviewable and releasable behind flags where appropriate.
+
+1. **Session event contract:** typed event schema, request IDs, cancellation tests.
+2. **Speech planner foundation:** semantic blocks and preserved offsets with fixtures.
+3. **Normalization pack:** shorthand, numbers, and code policies with fixtures.
+4. **Playback state machine:** exact offset pause/resume using a fake audio sink.
+5. **Sentence queue:** lookahead, back/forward, bounded cache, race tests.
+6. **Speed DSP spike:** compare embedded candidates and choose/package one.
+7. **Latency pass:** warmup, remove fixed waits, short first segment, measurement.
+8. **Progress UI:** structured states, first-audio estimate, remaining time.
+9. **Backend lab:** benchmark and package viable CPU/GPU providers.
+10. **Pocket adapter and bake-off:** samples, scorecard, promotion decision.
+11. **Reader UX:** navigation, profiles, dictionary, accessibility.
+12. **Release hardening:** installers, soak tests, upgrade path, docs.
+
+## Test strategy
+
+### Unit tests
+
+- Speech-plan parsing and source offsets.
+- Normalization word boundaries, punctuation, casing, locales, and overrides.
+- Playback state-machine transitions.
+- ETA estimator confidence and fallback behavior.
+- Backend capability and fallback selection.
+
+### Integration tests
+
+- UI -> Tauri -> sidecar event ordering with a fake synthesis engine.
+- Sidecar -> fake audio sink exact sample accounting.
+- New-request cancellation during planning, inference, queued playback, and pause.
+- Speed/voice change invalidation of current versus future buffers.
+- Speed-command acknowledgement and first changed audio block within 150 ms p95, tested throughout 0.75x–1.5x and at the 0.5x/2.0x advanced endpoints.
+- Frozen sidecar starts and synthesizes actual speech, not only a test beep.
+
+### Manual listening tests
+
+- Blind A/B files use equal loudness and anonymous engine labels.
+- Testers score naturalness, intelligibility, stress, pauses, and overall preference.
+- Runtime-speed listening is weighted to the recommended 0.75x–1.5x range, with separate artifact notes for the 0.5x and 2.0x advanced endpoints.
+- Failures are retained as regression fixtures with the planned spoken form.
+- At least one Windows and one Apple Silicon tester complete the release corpus.
+
+### Performance tests
+
+- Cold launch -> ready.
+- Warm request -> first audible sample.
+- Warm request -> complete generation.
+- Pause/resume and navigation response.
+- 1, 5, and 30-minute texts.
+- CPU, memory, queue depth, and package size.
+
+## v0.7.0 release gates
+
+v0.7.0 cannot ship until:
+
+- frontend, Rust, Python, and native Sonic automated suites pass;
+- the signed frozen Apple Silicon sidecar starts, prewarms Kokoro and Sonic, and reports healthy;
+- release CI produces healthy frozen Windows x64, macOS arm64, and macOS x64 packages before a release is published;
+- manual Apple Silicon testing confirms live speed, pause/resume, immediate widget close, and acceptable 0.75x–1.5x audio;
+- experimental Pocket/GPU work is absent or disabled by default;
+- installer upgrade from v0.6.3 preserves voice, volume, speed, and shortcut settings;
+- privacy review confirms no clipboard content is logged or transmitted by default;
+- README and release-testing documentation match the actual v1.0 model/runtime bundle; and
+- release checks are recorded in the candidate notes.
+
+The broader acceptance, corpus, accessibility, 30-minute soak, and engine-promotion gates below remain the path to v1.0 rather than blocking this focused v0.7.0 release.
+
+## Explicit non-goals for v0.7
+
+- Cloud TTS providers.
+- Automatic LLM rewriting of clipboard content.
+- Default voice cloning.
+- Shipping multiple large experimental engines in the installer.
+- Claiming universal GPU acceleration.
+- Full screen-reader or operating-system accessibility API replacement.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Rules improve some phrases but alter technical meaning | Profiles, source mapping, previewable overrides, regression corpus |
+| Time-stretch dependency breaks frozen builds | Select through a packaging spike before committing; retain next-sentence fallback |
+| Experimental model inflates downloads | Optional versioned model packs with checksum and removal controls |
+| GPU provider is slower or unstable | Calibration, explicit experiment flag, automatic CPU fallback |
+| More segmentation creates robotic gaps | Listening-tested pause policy and model/external pause separation |
+| Multiple worker threads leak stale events | Session IDs, cancellation tokens, bounded queues, state-machine tests |
+| ETA becomes misleading | Local rolling estimates, confidence threshold, indeterminate fallback |
+
+## Definition of done
+
+The release is done only when the packaged applications—not only development mode—demonstrate the control, speech-planning, latency, progress, privacy, and fallback behavior in this roadmap, with recorded evidence from the test corpus and supported platform matrix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/analyze_tts_events.py
+++ b/scripts/analyze_tts_events.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Convert sidecar lifecycle logs into request-level benchmark JSON.
+
+Usage:
+    python scripts/analyze_tts_events.py path/to/kokoro-sidecar.log --pretty
+    cat kokoro-sidecar.log | python scripts/analyze_tts_events.py -
+
+The output contains request IDs, non-sensitive request metadata, event timing,
+and derived durations. Clipboard text is never part of the lifecycle protocol.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Iterable, TextIO
+
+
+EVENT_PREFIX = "[TTS_EVENT] "
+
+
+def parse_event_lines(lines: Iterable[str]) -> list[dict[str, Any]]:
+    events = []
+    for line in lines:
+        marker = line.find(EVENT_PREFIX)
+        if marker < 0:
+            continue
+        payload = line[marker + len(EVENT_PREFIX):].strip()
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if (
+            event.get("schemaVersion") == 1
+            and isinstance(event.get("requestId"), str)
+            and isinstance(event.get("event"), str)
+            and isinstance(event.get("timestampMs"), int)
+            and isinstance(event.get("data", {}), dict)
+        ):
+            events.append(event)
+    return events
+
+
+def _duration(timestamps: dict[str, int], end: str, start: str) -> int | None:
+    if end not in timestamps or start not in timestamps:
+        return None
+    return timestamps[end] - timestamps[start]
+
+
+def summarize_events(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    grouped: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
+    for event in events:
+        grouped.setdefault(event["requestId"], []).append(event)
+
+    requests = []
+    for request_id, request_events in grouped.items():
+        request_events.sort(key=lambda item: item["timestampMs"])
+        timestamps: dict[str, int] = {}
+        metadata: dict[str, Any] = {}
+        errors = []
+        status = "incomplete"
+
+        for event in request_events:
+            name = event["event"]
+            timestamps.setdefault(name, event["timestampMs"])
+            if name == "request_received":
+                metadata = {
+                    key: event["data"][key]
+                    for key in ("textLength", "voice", "speed")
+                    if key in event["data"]
+                }
+            elif name == "error":
+                errors.append(
+                    {
+                        key: event["data"][key]
+                        for key in ("stage", "message")
+                        if key in event["data"]
+                    }
+                )
+                status = "error"
+            elif name == "cancelled" and status != "error":
+                status = "cancelled"
+            elif name == "playback_finished" and status not in {"error", "cancelled"}:
+                status = "completed"
+
+        durations = {
+            "engineReadyMs": _duration(timestamps, "engine_ready", "request_received"),
+            "inferenceStartMs": _duration(timestamps, "inference_started", "request_received"),
+            "firstChunkReadyMs": _duration(timestamps, "chunk_ready", "request_received"),
+            "firstAudioMs": _duration(timestamps, "playback_started", "request_received"),
+            "playbackMs": _duration(timestamps, "playback_finished", "playback_started"),
+            "totalMs": _duration(timestamps, "playback_finished", "request_received"),
+        }
+
+        requests.append(
+            {
+                "requestId": request_id,
+                "status": status,
+                "metadata": metadata,
+                "timestampsMs": timestamps,
+                "durationsMs": durations,
+                "errors": errors,
+                "eventCount": len(request_events),
+            }
+        )
+
+    return {"schemaVersion": 1, "requests": requests}
+
+
+def analyze_stream(stream: TextIO) -> dict[str, Any]:
+    return summarize_events(parse_event_lines(stream))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", nargs="?", default="-", help="Sidecar log path or - for stdin")
+    parser.add_argument("--output", "-o", help="Write JSON to this path instead of stdout")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        result = analyze_stream(sys.stdin)
+    else:
+        with Path(args.input).open(encoding="utf-8") as stream:
+            result = analyze_stream(stream)
+
+    rendered = json.dumps(result, indent=2 if args.pretty else None, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_kokoro_backend.py
+++ b/scripts/benchmark_kokoro_backend.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Benchmark Kokoro model loading and warm first-chunk synthesis.
+
+The command uses the repository's bundled model and versioned reader-quality
+corpus. It records fixture identity and length, never the source text itself.
+
+Examples:
+    .sidecar-venv/bin/python scripts/benchmark_kokoro_backend.py --device cpu
+    PYTORCH_ENABLE_MPS_FALLBACK=1 .sidecar-venv/bin/python \
+      scripts/benchmark_kokoro_backend.py --device mps --repetitions 3 --pretty
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import math
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = PROJECT_ROOT / "tests" / "fixtures" / "reader_quality_v1.json"
+DEFAULT_MODEL_DIR = PROJECT_ROOT / "sidecar" / "model"
+LATENCY_SUITE_FIXTURES = [
+    "chat-ok-ellipsis",
+    "technical-identifiers",
+    "structure-paragraph-breaks",
+    "long-form-single-sentence",
+]
+
+
+def load_fixture(corpus_path: Path, fixture_id: str) -> dict[str, Any]:
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    for fixture in corpus["cases"]:
+        if fixture["id"] == fixture_id:
+            return fixture
+    available = ", ".join(item["id"] for item in corpus["cases"])
+    raise ValueError(f"Unknown fixture {fixture_id!r}. Available fixtures: {available}")
+
+
+def percentile(values: list[float], percentile_value: float) -> float:
+    """Return a nearest-rank percentile suitable for small benchmark samples."""
+
+    if not values:
+        raise ValueError("values must not be empty")
+    if percentile_value < 0 or percentile_value > 100:
+        raise ValueError("percentile must be between 0 and 100")
+    ordered = sorted(values)
+    rank = max(1, math.ceil((percentile_value / 100) * len(ordered)))
+    return ordered[rank - 1]
+
+
+def summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    if not runs:
+        raise ValueError("runs must not be empty")
+
+    successful = [run for run in runs if "firstChunkMs" in run]
+    failed_count = len(runs) - len(successful)
+    if not successful:
+        return {
+            "successfulRuns": 0,
+            "failedRuns": failed_count,
+            "firstChunkMedianMs": None,
+            "firstChunkP95Ms": None,
+            "realTimeFactorMedian": None,
+        }
+
+    first_chunk = [run["firstChunkMs"] for run in successful]
+    real_time_factors = [run["realTimeFactor"] for run in successful]
+    return {
+        "successfulRuns": len(successful),
+        "failedRuns": failed_count,
+        "firstChunkMedianMs": round(statistics.median(first_chunk), 3),
+        "firstChunkP95Ms": round(percentile(first_chunk, 95), 3),
+        "realTimeFactorMedian": round(statistics.median(real_time_factors), 4),
+    }
+
+
+def summarize_by_fixture(runs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    fixture_ids = dict.fromkeys(run["fixtureId"] for run in runs)
+    return {
+        fixture_id: summarize_runs(
+            [run for run in runs if run["fixtureId"] == fixture_id]
+        )
+        for fixture_id in fixture_ids
+    }
+
+
+def synchronize_device(torch_module: Any, device: str) -> None:
+    if device == "cuda":
+        torch_module.cuda.synchronize()
+    elif device == "mps":
+        torch_module.mps.synchronize()
+
+
+def measure_call(
+    call: Callable[[], Any],
+    synchronize: Callable[[], None],
+) -> tuple[Any, float]:
+    synchronize()
+    start = time.perf_counter()
+    value = call()
+    synchronize()
+    return value, (time.perf_counter() - start) * 1000
+
+
+def benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    import torch
+    from kokoro import KModel, KPipeline
+
+    fixture_ids = LATENCY_SUITE_FIXTURES if args.suite == "latency" else [args.fixture]
+    fixtures = [load_fixture(args.corpus, fixture_id) for fixture_id in fixture_ids]
+    model_path = args.model_dir / "kokoro-v1_0.pth"
+    config_path = args.model_dir / "config.json"
+    voice_path = args.model_dir / "voices" / f"{args.voice}.pt"
+    for required in (model_path, config_path, voice_path):
+        if not required.is_file():
+            raise FileNotFoundError(f"Required benchmark asset not found: {required}")
+
+    if args.device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not available")
+    if args.device == "mps" and not torch.backends.mps.is_available():
+        raise RuntimeError("MPS was requested but is not available")
+
+    synchronize = lambda: synchronize_device(torch, args.device)
+
+    model, model_load_ms = measure_call(
+        lambda: KModel(
+            repo_id="hexgrad/Kokoro-82M",
+            config=str(config_path),
+            model=str(model_path),
+        ).to(args.device).eval(),
+        synchronize,
+    )
+    pipeline, pipeline_ready_ms = measure_call(
+        lambda: KPipeline(
+            lang_code="a",
+            repo_id="hexgrad/Kokoro-82M",
+            model=model,
+        ),
+        synchronize,
+    )
+
+    def synthesize_first_chunk(source_text: str):
+        return next(
+            pipeline(
+                source_text,
+                voice=str(voice_path),
+                speed=args.speed,
+            )
+        )
+
+    for _ in range(args.warmup_runs):
+        measure_call(lambda: synthesize_first_chunk("Okay."), synchronize)
+
+    runs = []
+    for index in range(args.repetitions):
+        for fixture in fixtures:
+            text = fixture["input"]
+            try:
+                result, first_chunk_ms = measure_call(
+                    lambda text=text: synthesize_first_chunk(text),
+                    synchronize,
+                )
+            except Exception as error:
+                runs.append(
+                    {
+                        "run": index + 1,
+                        "fixtureId": fixture["id"],
+                        "textLength": len(text),
+                        "wordCount": len(text.split()),
+                        "errorType": type(error).__name__,
+                        "error": str(error),
+                    }
+                )
+                continue
+            sample_count = int(result.audio.shape[-1])
+            audio_duration_ms = sample_count / 24_000 * 1000
+            runs.append(
+                {
+                    "run": index + 1,
+                    "fixtureId": fixture["id"],
+                    "textLength": len(text),
+                    "wordCount": len(text.split()),
+                    "firstChunkMs": round(first_chunk_ms, 3),
+                    "sampleCount": sample_count,
+                    "audioDurationMs": round(audio_duration_ms, 3),
+                    "realTimeFactor": round(first_chunk_ms / audio_duration_ms, 4),
+                }
+            )
+
+    try:
+        kokoro_version = importlib.metadata.version("kokoro")
+    except importlib.metadata.PackageNotFoundError:
+        kokoro_version = "unknown"
+
+    return {
+        "schemaVersion": 1,
+        "benchmark": "kokoro-first-chunk",
+        "recordedAtUnixMs": time.time_ns() // 1_000_000,
+        "environment": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "kokoro": kokoro_version,
+            "device": args.device,
+            "mpsAvailable": bool(torch.backends.mps.is_available()),
+            "cudaAvailable": bool(torch.cuda.is_available()),
+        },
+        "fixtureSet": {
+            "corpusSchemaVersion": 1,
+            "suite": args.suite,
+            "fixtures": [
+                {
+                    "id": fixture["id"],
+                    "category": fixture["category"],
+                    "textLength": len(fixture["input"]),
+                    "wordCount": len(fixture["input"].split()),
+                }
+                for fixture in fixtures
+            ],
+        },
+        "settings": {
+            "voice": args.voice,
+            "speed": args.speed,
+            "warmupRuns": args.warmup_runs,
+            "repetitions": args.repetitions,
+        },
+        "startup": {
+            "modelLoadMs": round(model_load_ms, 3),
+            "pipelineReadyMs": round(pipeline_ready_ms, 3),
+            "totalReadyMs": round(model_load_ms + pipeline_ready_ms, 3),
+        },
+        "summary": summarize_runs(runs),
+        "summaryByFixture": summarize_by_fixture(runs),
+        "runs": runs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", choices=["cpu", "mps", "cuda"], default="cpu")
+    parser.add_argument("--suite", choices=["single", "latency"], default="single")
+    parser.add_argument("--fixture", default="chat-ok-ellipsis")
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--model-dir", type=Path, default=DEFAULT_MODEL_DIR)
+    parser.add_argument("--voice", default="am_fenrir")
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--output", "-o", type=Path)
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    if args.repetitions < 1:
+        parser.error("--repetitions must be at least 1")
+    if args.warmup_runs < 0:
+        parser.error("--warmup-runs must not be negative")
+    if args.speed < 0.5 or args.speed > 2.0:
+        parser.error("--speed must be between 0.5 and 2.0")
+
+    try:
+        result = benchmark(args)
+    except Exception as error:
+        print(f"Benchmark failed: {error}", file=sys.stderr)
+        return 1
+
+    rendered = json.dumps(result, indent=2 if args.pretty else None, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_pocket_tts.py
+++ b/scripts/benchmark_pocket_tts.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Benchmark Pocket TTS streaming latency without adding it to app dependencies.
+
+Install Pocket TTS in an isolated environment, then run for example:
+
+    python scripts/benchmark_pocket_tts.py --suite latency --repetitions 3 --pretty
+
+The output records fixture identity and shape, never the source text itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import math
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    import resource
+except ImportError:  # Windows does not provide the Unix resource module.
+    resource = None
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = PROJECT_ROOT / "tests" / "fixtures" / "reader_quality_v1.json"
+LATENCY_SUITE_FIXTURES = [
+    "chat-ok-ellipsis",
+    "technical-identifiers",
+    "structure-paragraph-breaks",
+    "long-form-single-sentence",
+]
+
+
+def peak_rss_bytes() -> int | None:
+    if resource is None:
+        return None
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # macOS reports bytes; Linux and the other supported Unix runners report KiB.
+    return peak if sys.platform == "darwin" else peak * 1024
+
+
+def load_fixture(corpus_path: Path, fixture_id: str) -> dict[str, Any]:
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    for fixture in corpus["cases"]:
+        if fixture["id"] == fixture_id:
+            return fixture
+    raise ValueError(f"Unknown fixture {fixture_id!r}")
+
+
+def percentile(values: list[float], percentile_value: float) -> float:
+    if not values:
+        raise ValueError("values must not be empty")
+    ordered = sorted(values)
+    rank = max(1, math.ceil((percentile_value / 100) * len(ordered)))
+    return ordered[rank - 1]
+
+
+def summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    successful = [run for run in runs if "firstChunkMs" in run]
+    if not successful:
+        return {
+            "successfulRuns": 0,
+            "failedRuns": len(runs),
+            "firstChunkMedianMs": None,
+            "firstChunkP95Ms": None,
+            "realTimeFactorMedian": None,
+        }
+    first_chunks = [run["firstChunkMs"] for run in successful]
+    factors = [run["realTimeFactor"] for run in successful]
+    return {
+        "successfulRuns": len(successful),
+        "failedRuns": len(runs) - len(successful),
+        "firstChunkMedianMs": round(statistics.median(first_chunks), 3),
+        "firstChunkP95Ms": round(percentile(first_chunks, 95), 3),
+        "realTimeFactorMedian": round(statistics.median(factors), 4),
+    }
+
+
+def benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    from pocket_tts import TTSModel
+
+    fixture_ids = LATENCY_SUITE_FIXTURES if args.suite == "latency" else [args.fixture]
+    fixtures = [load_fixture(args.corpus, fixture_id) for fixture_id in fixture_ids]
+
+    load_started = time.perf_counter()
+    model = TTSModel.load_model(quantize=args.quantize)
+    model_load_ms = (time.perf_counter() - load_started) * 1000
+
+    voice_started = time.perf_counter()
+    voice_state = model.get_state_for_audio_prompt(args.voice)
+    voice_ready_ms = (time.perf_counter() - voice_started) * 1000
+
+    def stream_once(text: str) -> dict[str, float | int]:
+        started = time.perf_counter()
+        first_chunk_ms = None
+        sample_count = 0
+        chunk_count = 0
+        for audio in model.generate_audio_stream(
+            voice_state,
+            text,
+            max_tokens=args.max_tokens,
+            copy_state=True,
+        ):
+            if first_chunk_ms is None:
+                first_chunk_ms = (time.perf_counter() - started) * 1000
+            sample_count += int(audio.shape[-1])
+            chunk_count += 1
+        generation_ms = (time.perf_counter() - started) * 1000
+        if first_chunk_ms is None or sample_count == 0:
+            raise RuntimeError("Pocket TTS produced no audio")
+        duration_ms = sample_count / model.sample_rate * 1000
+        return {
+            "firstChunkMs": round(first_chunk_ms, 3),
+            "generationMs": round(generation_ms, 3),
+            "sampleCount": sample_count,
+            "chunkCount": chunk_count,
+            "audioDurationMs": round(duration_ms, 3),
+            "realTimeFactor": round(generation_ms / duration_ms, 4),
+        }
+
+    for _ in range(args.warmup_runs):
+        stream_once("Okay.")
+
+    runs = []
+    for repetition in range(args.repetitions):
+        for fixture in fixtures:
+            base = {
+                "run": repetition + 1,
+                "fixtureId": fixture["id"],
+                "textLength": len(fixture["input"]),
+                "wordCount": len(fixture["input"].split()),
+            }
+            try:
+                runs.append({**base, **stream_once(fixture["input"])})
+            except Exception as error:
+                runs.append({
+                    **base,
+                    "errorType": type(error).__name__,
+                    "error": str(error),
+                })
+
+    try:
+        version = importlib.metadata.version("pocket-tts")
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+
+    return {
+        "schemaVersion": 1,
+        "benchmark": "pocket-tts-streaming",
+        "recordedAtUnixMs": time.time_ns() // 1_000_000,
+        "environment": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "pocketTts": version,
+            "device": "cpu",
+        },
+        "fixtureSet": {
+            "corpusSchemaVersion": 1,
+            "suite": args.suite,
+            "fixtures": [
+                {
+                    "id": fixture["id"],
+                    "category": fixture["category"],
+                    "textLength": len(fixture["input"]),
+                    "wordCount": len(fixture["input"].split()),
+                }
+                for fixture in fixtures
+            ],
+        },
+        "settings": {
+            "voice": args.voice,
+            "quantize": args.quantize,
+            "maxTokens": args.max_tokens,
+            "warmupRuns": args.warmup_runs,
+            "repetitions": args.repetitions,
+        },
+        "startup": {
+            "modelLoadMs": round(model_load_ms, 3),
+            "voiceReadyMs": round(voice_ready_ms, 3),
+            "totalReadyMs": round(model_load_ms + voice_ready_ms, 3),
+        },
+        "summary": summarize_runs(runs),
+        "peakRssBytes": peak_rss_bytes(),
+        "runs": runs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", choices=["single", "latency"], default="single")
+    parser.add_argument("--fixture", default="chat-ok-ellipsis")
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--voice", default="alba")
+    parser.add_argument("--max-tokens", type=int, default=400)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--quantize", action="store_true")
+    parser.add_argument("--output", "-o", type=Path)
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    if args.repetitions < 1 or args.warmup_runs < 0 or args.max_tokens < 1:
+        parser.error("repetitions/max-tokens must be positive; warmup-runs cannot be negative")
+
+    try:
+        result = benchmark(args)
+    except Exception as error:
+        print(f"Benchmark failed: {error}")
+        return 1
+    rendered = json.dumps(result, indent=2 if args.pretty else None, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_local_sidecar.py
+++ b/scripts/build_local_sidecar.py
@@ -46,6 +46,9 @@ def run():
         env=venv_env,
     )
 
+    print("Building Sonic real-time speed DSP...")
+    subprocess.check_call([venv_python, os.path.join("scripts", "build_sonic_dsp.py")])
+
     # 4. Build with PyInstaller
     print("Building sidecar executable...")
     # We use --onefile and --name kokoro
@@ -69,6 +72,13 @@ def run():
         "--collect-all", "spacy",
         "--collect-all", "en_core_web_sm",
     ]
+    if os.name == 'nt':
+        sonic_library = os.path.join("sidecar", "native", "sonic_kctts.dll")
+    elif sys.platform == 'darwin':
+        sonic_library = os.path.join("sidecar", "native", "libsonic_kctts.dylib")
+    else:
+        sonic_library = os.path.join("sidecar", "native", "libsonic_kctts.so")
+    pyinstaller_args.extend(["--add-binary", f"{sonic_library}{os.pathsep}native"])
     if os.name != 'nt':
         # macOS validates code signatures when PyInstaller's onefile bootloader
         # extracts and loads the bundled Python framework. Sign all collected

--- a/scripts/build_sonic_dsp.py
+++ b/scripts/build_sonic_dsp.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Build the vendored Sonic speech-rate DSP as a small shared library."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = PROJECT_ROOT / "third_party" / "sonic"
+DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "sidecar" / "native"
+
+
+def library_filename(system: str | None = None) -> str:
+    system = system or platform.system()
+    if system == "Windows":
+        return "sonic_kctts.dll"
+    if system == "Darwin":
+        return "libsonic_kctts.dylib"
+    return "libsonic_kctts.so"
+
+
+def build(output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / library_filename()
+    sonic_c = SOURCE_DIR / "sonic.c"
+    wrapper_c = SOURCE_DIR / "sonic_wrapper.c"
+
+    if platform.system() == "Windows":
+        compiler = shutil.which("cl")
+        if compiler:
+            command = [
+                compiler,
+                "/nologo",
+                "/O2",
+                "/LD",
+                f"/I{SOURCE_DIR}",
+                str(sonic_c),
+                str(wrapper_c),
+                "/link",
+                f"/OUT:{output}",
+            ]
+        else:
+            compiler = shutil.which("clang") or shutil.which("gcc")
+            if not compiler:
+                raise RuntimeError("No Windows C compiler found (cl, clang, or gcc)")
+            command = [
+                compiler,
+                "-O3",
+                "-shared",
+                f"-I{SOURCE_DIR}",
+                str(sonic_c),
+                str(wrapper_c),
+                "-o",
+                str(output),
+            ]
+    else:
+        compiler = shutil.which(os.environ.get("CC", "cc"))
+        if not compiler:
+            raise RuntimeError("No C compiler found")
+        shared_flag = "-dynamiclib" if platform.system() == "Darwin" else "-shared"
+        command = [
+            compiler,
+            "-O3",
+            shared_flag,
+            "-fPIC",
+            f"-I{SOURCE_DIR}",
+            str(sonic_c),
+            str(wrapper_c),
+            "-o",
+            str(output),
+        ]
+
+    subprocess.check_call(command)
+    if not output.is_file():
+        raise RuntimeError(f"Compiler did not create {output}")
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args()
+    try:
+        output = build(args.output_dir.resolve())
+    except Exception as error:
+        print(f"Sonic DSP build failed: {error}", file=sys.stderr)
+        return 1
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_analyze_tts_events.py
+++ b/scripts/test_analyze_tts_events.py
@@ -1,0 +1,83 @@
+import io
+import unittest
+
+from scripts.analyze_tts_events import analyze_stream, parse_event_lines
+
+
+def event_line(event, timestamp, data=None, request_id="request-1"):
+    import json
+
+    return "[TTS_EVENT] " + json.dumps(
+        {
+            "schemaVersion": 1,
+            "requestId": request_id,
+            "event": event,
+            "timestampMs": timestamp,
+            "data": data or {},
+        }
+    )
+
+
+class AnalyzeTtsEventsTests(unittest.TestCase):
+    def test_ignores_unstructured_and_malformed_lines(self):
+        lines = [
+            "[Sidecar] ordinary log\n",
+            "[TTS_EVENT] not-json\n",
+            event_line("request_received", 100) + "\n",
+        ]
+
+        events = parse_event_lines(lines)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["event"], "request_received")
+
+    def test_summarizes_first_audio_and_total_latency(self):
+        log = "\n".join(
+            [
+                event_line(
+                    "request_received",
+                    100,
+                    {"textLength": 42, "voice": "am_fenrir", "speed": 1.0},
+                ),
+                event_line("engine_ready", 140),
+                event_line("inference_started", 150),
+                event_line("chunk_ready", 500, {"chunkIndex": 0}),
+                event_line("chunk_ready", 700, {"chunkIndex": 1}),
+                event_line("playback_started", 620),
+                event_line("playback_finished", 2100),
+            ]
+        )
+
+        summary = analyze_stream(io.StringIO(log))["requests"][0]
+
+        self.assertEqual(summary["status"], "completed")
+        self.assertEqual(summary["metadata"]["textLength"], 42)
+        self.assertEqual(summary["durationsMs"]["engineReadyMs"], 40)
+        self.assertEqual(summary["durationsMs"]["firstChunkReadyMs"], 400)
+        self.assertEqual(summary["durationsMs"]["firstAudioMs"], 520)
+        self.assertEqual(summary["durationsMs"]["playbackMs"], 1480)
+        self.assertEqual(summary["durationsMs"]["totalMs"], 2000)
+
+    def test_keeps_requests_and_failures_separate(self):
+        log = "\n".join(
+            [
+                event_line("request_received", 100),
+                event_line("cancelled", 200),
+                event_line("request_received", 300, request_id="request-2"),
+                event_line(
+                    "error",
+                    350,
+                    {"stage": "inference", "message": "failed"},
+                    request_id="request-2",
+                ),
+            ]
+        )
+
+        requests = analyze_stream(io.StringIO(log))["requests"]
+
+        self.assertEqual([item["status"] for item in requests], ["cancelled", "error"])
+        self.assertEqual(requests[1]["errors"][0]["stage"], "inference")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_benchmark_kokoro_backend.py
+++ b/scripts/test_benchmark_kokoro_backend.py
@@ -1,0 +1,83 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.benchmark_kokoro_backend import (
+    load_fixture,
+    percentile,
+    summarize_by_fixture,
+    summarize_runs,
+)
+
+
+class BenchmarkKokoroBackendTests(unittest.TestCase):
+    def test_nearest_rank_percentile(self):
+        self.assertEqual(percentile([40, 10, 30, 20], 50), 20)
+        self.assertEqual(percentile([40, 10, 30, 20], 95), 40)
+        with self.assertRaises(ValueError):
+            percentile([], 95)
+
+    def test_summarizes_runs(self):
+        summary = summarize_runs(
+            [
+                {"firstChunkMs": 100.0, "realTimeFactor": 0.5},
+                {"firstChunkMs": 300.0, "realTimeFactor": 0.7},
+                {"firstChunkMs": 200.0, "realTimeFactor": 0.6},
+            ]
+        )
+
+        self.assertEqual(summary["firstChunkMedianMs"], 200.0)
+        self.assertEqual(summary["firstChunkP95Ms"], 300.0)
+        self.assertEqual(summary["realTimeFactorMedian"], 0.6)
+        self.assertEqual(summary["successfulRuns"], 3)
+        self.assertEqual(summary["failedRuns"], 0)
+
+    def test_loads_fixture_by_id_without_copying_corpus_logic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            corpus_path = Path(directory) / "corpus.json"
+            corpus_path.write_text(
+                json.dumps(
+                    {
+                        "cases": [
+                            {"id": "first", "input": "One", "category": "test"},
+                            {"id": "second", "input": "Two", "category": "test"},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            fixture = load_fixture(corpus_path, "second")
+
+            self.assertEqual(fixture["input"], "Two")
+            with self.assertRaises(ValueError):
+                load_fixture(corpus_path, "missing")
+
+    def test_summarizes_each_fixture_independently(self):
+        summary = summarize_by_fixture(
+            [
+                {"fixtureId": "a", "firstChunkMs": 100.0, "realTimeFactor": 0.5},
+                {"fixtureId": "b", "firstChunkMs": 300.0, "realTimeFactor": 0.7},
+                {"fixtureId": "a", "firstChunkMs": 200.0, "realTimeFactor": 0.6},
+            ]
+        )
+
+        self.assertEqual(summary["a"]["firstChunkMedianMs"], 150.0)
+        self.assertEqual(summary["b"]["firstChunkMedianMs"], 300.0)
+
+    def test_reports_failed_runs_without_hiding_successful_metrics(self):
+        summary = summarize_runs(
+            [
+                {"firstChunkMs": 100.0, "realTimeFactor": 0.5},
+                {"errorType": "RuntimeError", "error": "unsupported"},
+            ]
+        )
+
+        self.assertEqual(summary["successfulRuns"], 1)
+        self.assertEqual(summary["failedRuns"], 1)
+        self.assertEqual(summary["firstChunkMedianMs"], 100.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_benchmark_pocket_tts.py
+++ b/scripts/test_benchmark_pocket_tts.py
@@ -1,0 +1,44 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+from benchmark_pocket_tts import peak_rss_bytes, summarize_runs
+
+
+class PocketTtsBenchmarkTests(unittest.TestCase):
+    def test_summarizes_success_and_failure_without_model_dependency(self):
+        summary = summarize_runs([
+            {"firstChunkMs": 100, "realTimeFactor": 0.2},
+            {"firstChunkMs": 200, "realTimeFactor": 0.4},
+            {"firstChunkMs": 300, "realTimeFactor": 0.6},
+            {"error": "failed"},
+        ])
+
+        self.assertEqual(summary["successfulRuns"], 3)
+        self.assertEqual(summary["failedRuns"], 1)
+        self.assertEqual(summary["firstChunkMedianMs"], 200)
+        self.assertEqual(summary["firstChunkP95Ms"], 300)
+        self.assertEqual(summary["realTimeFactorMedian"], 0.4)
+
+    def test_reports_empty_success_summary(self):
+        summary = summarize_runs([{"error": "failed"}])
+        self.assertEqual(summary["successfulRuns"], 0)
+        self.assertIsNone(summary["firstChunkMedianMs"])
+
+    def test_normalizes_unix_peak_memory_to_bytes(self):
+        fake_resource = unittest.mock.Mock()
+        fake_resource.RUSAGE_SELF = 0
+        fake_resource.getrusage.return_value.ru_maxrss = 123
+        with (
+            patch("benchmark_pocket_tts.resource", fake_resource),
+            patch.object(sys, "platform", "linux"),
+        ):
+            self.assertEqual(peak_rss_bytes(), 123 * 1024)
+
+    def test_allows_memory_metric_to_be_unavailable_on_windows(self):
+        with patch("benchmark_pocket_tts.resource", None):
+            self.assertIsNone(peak_rss_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_build_sonic_dsp.py
+++ b/scripts/test_build_sonic_dsp.py
@@ -1,0 +1,14 @@
+import unittest
+
+from build_sonic_dsp import library_filename
+
+
+class BuildSonicDspTests(unittest.TestCase):
+    def test_uses_platform_specific_library_names(self):
+        self.assertEqual(library_filename("Windows"), "sonic_kctts.dll")
+        self.assertEqual(library_filename("Darwin"), "libsonic_kctts.dylib")
+        self.assertEqual(library_filename("Linux"), "libsonic_kctts.so")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sidecar/audio_playback.py
+++ b/sidecar/audio_playback.py
@@ -1,0 +1,221 @@
+"""Small, deterministic audio-write primitives used by the sidecar.
+
+This module intentionally has no sounddevice or model imports. Tests can use a
+fake stream to verify exact offsets, interruption behavior, and event timing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from queue import Empty
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class BlockWriteResult:
+    next_offset: int
+    completed: bool
+
+
+@dataclass(frozen=True)
+class AudioChunk:
+    index: int
+    audio: Any
+    pause_after_ms: int
+    segment_id: str
+
+
+@dataclass(frozen=True)
+class QueuePlaybackResult:
+    completed_chunks: int
+    cancelled: bool
+
+
+def write_audio_blocks(
+    stream: Any,
+    audio: Any,
+    *,
+    start_offset: int,
+    block_size: int,
+    should_interrupt: Callable[[], bool],
+    before_write: Callable[[int, int], None] | None = None,
+    after_write: Callable[[int, int], None] | None = None,
+) -> BlockWriteResult:
+    """Write audio sequentially and return the first unwritten sample offset.
+
+    The offset advances only after ``stream.write`` succeeds. A caller can retain
+    ``next_offset`` across pause/resume without replaying completed blocks.
+    """
+
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+    if start_offset < 0 or start_offset > len(audio):
+        raise ValueError("start_offset is outside the audio buffer")
+
+    offset = start_offset
+    while offset < len(audio):
+        if should_interrupt():
+            return BlockWriteResult(next_offset=offset, completed=False)
+
+        end_offset = min(offset + block_size, len(audio))
+        if before_write is not None:
+            before_write(offset, end_offset)
+        start_offset_for_write = offset
+        stream.write(audio[offset:end_offset])
+        offset = end_offset
+        if after_write is not None:
+            after_write(start_offset_for_write, end_offset)
+
+    return BlockWriteResult(next_offset=offset, completed=True)
+
+
+def play_queued_audio(
+    stream: Any,
+    audio_queue: Any,
+    session: Any,
+    *,
+    prepare_audio: Callable[[AudioChunk], Any],
+    block_size: int,
+    on_first_write: Callable[[AudioChunk], None] | None = None,
+    on_paused: Callable[[Any], None] | None = None,
+    on_resumed: Callable[[Any], None] | None = None,
+    process_audio_block: Callable[[Any], Any] | None = None,
+    flush_audio: Callable[[], Any] | None = None,
+    source_block_size: int = 480,
+    queue_timeout: float = 0.05,
+) -> QueuePlaybackResult:
+    """Consume ``AudioChunk`` items until a ``None`` sentinel or cancellation.
+
+    This is the production playback state machine, with model and sounddevice
+    details injected by the caller so deterministic fake-stream tests exercise
+    the same chunk ordering and exact-offset pause/resume behavior as the app.
+    """
+    if queue_timeout <= 0:
+        raise ValueError("queue_timeout must be positive")
+    if process_audio_block is not None and source_block_size <= 0:
+        raise ValueError("source_block_size must be positive")
+
+    current_chunk = None
+    current_audio = None
+    current_offset = 0
+    pending_audio = None
+    pending_offset = 0
+    end_received = False
+    completed_chunks = 0
+    playback_started = False
+    stream.start()
+
+    while not session.cancel_event.is_set():
+        if session.pause_event.is_set():
+            stream.stop()
+            if session.acknowledge_pause() and on_paused is not None:
+                on_paused(session.position())
+            session.cancel_event.wait(0.01)
+            continue
+
+        if not stream.active:
+            stream.start()
+            if session.acknowledge_resume() and on_resumed is not None:
+                on_resumed(session.position())
+
+        def after_write(start_offset: int, end_offset: int) -> None:
+            nonlocal playback_started
+            if not playback_started and current_chunk is not None:
+                if on_first_write is not None:
+                    on_first_write(current_chunk)
+                playback_started = True
+
+        if pending_audio is not None:
+            result = write_audio_blocks(
+                stream,
+                pending_audio,
+                start_offset=pending_offset,
+                block_size=block_size,
+                should_interrupt=lambda: (
+                    session.cancel_event.is_set() or session.pause_event.is_set()
+                ),
+                after_write=after_write,
+            )
+            pending_offset = result.next_offset
+            if not result.completed:
+                if session.pause_event.is_set():
+                    stream.stop()
+                    if session.acknowledge_pause() and on_paused is not None:
+                        on_paused(session.position())
+                continue
+            pending_audio = None
+            pending_offset = 0
+            continue
+
+        if end_received:
+            break
+
+        if current_chunk is None:
+            try:
+                current_chunk = audio_queue.get(timeout=queue_timeout)
+            except Empty:
+                continue
+            if current_chunk is None:
+                end_received = True
+                if flush_audio is not None:
+                    flushed_audio = flush_audio()
+                    if len(flushed_audio) > 0:
+                        pending_audio = flushed_audio
+                continue
+
+        if current_audio is None:
+            current_audio = prepare_audio(current_chunk)
+            current_offset = 0
+            session.set_position(current_chunk.index, current_offset)
+
+        if process_audio_block is not None:
+            if current_offset < len(current_audio):
+                end_offset = min(current_offset + source_block_size, len(current_audio))
+                pending_audio = process_audio_block(
+                    current_audio[current_offset:end_offset]
+                )
+                current_offset = end_offset
+                session.set_position(current_chunk.index, current_offset)
+                if len(pending_audio) == 0:
+                    pending_audio = None
+                continue
+
+            audio_queue.task_done()
+            completed_chunks += 1
+            current_chunk = None
+            current_audio = None
+            current_offset = 0
+            session.clear_position()
+            continue
+
+        result = write_audio_blocks(
+            stream,
+            current_audio,
+            start_offset=current_offset,
+            block_size=block_size,
+            should_interrupt=lambda: (
+                session.cancel_event.is_set() or session.pause_event.is_set()
+            ),
+            after_write=after_write,
+        )
+        current_offset = result.next_offset
+        session.set_position(current_chunk.index, current_offset)
+
+        if not result.completed:
+            if session.pause_event.is_set():
+                stream.stop()
+                if session.acknowledge_pause() and on_paused is not None:
+                    on_paused(session.position())
+            continue
+
+        audio_queue.task_done()
+        completed_chunks += 1
+        current_chunk = None
+        current_audio = None
+        current_offset = 0
+        session.clear_position()
+
+    return QueuePlaybackResult(
+        completed_chunks=completed_chunks,
+        cancelled=session.cancel_event.is_set(),
+    )

--- a/sidecar/kokoro_server.py
+++ b/sidecar/kokoro_server.py
@@ -3,7 +3,20 @@ import sys
 import builtins
 import threading
 import argparse
+import uuid
 from flask import Flask, request, jsonify
+
+try:
+    from .tts_protocol import encode_tts_event, normalize_synthesis_segments
+    from .audio_playback import AudioChunk, play_queued_audio
+    from .playback_session import PlaybackSessionController
+    from .sonic_speed import SonicSpeedProcessor
+except ImportError:
+    # Script/PyInstaller execution places the sidecar directory on sys.path.
+    from tts_protocol import encode_tts_event, normalize_synthesis_segments
+    from audio_playback import AudioChunk, play_queued_audio
+    from playback_session import PlaybackSessionController
+    from sonic_speed import SonicSpeedProcessor
 
 # Make stdout write-through (unbuffered) so every write is flushed to disk
 # immediately. This is critical on Windows where PyInstaller --onefile processes
@@ -87,31 +100,77 @@ except Exception:
     sys.exit(1)
 
 app = Flask(__name__)
-stop_event = threading.Event()
-pause_event = threading.Event() # Issue #5: Support Pause/Resume
 pipeline = None
+pipeline_lock = threading.Lock()
+inference_lock = threading.Lock()
 request_counter = 0
+session_controller = PlaybackSessionController()
+
+
+def emit_tts_event(event, request_id, **data):
+    """Write one machine-readable lifecycle event without clipboard content."""
+    print(encode_tts_event(event, request_id, **data))
+
+
+def validate_control_request(data):
+    """Reject delayed controls intended for a playback session that is no longer active."""
+    request_id = str(data.get("request_id") or "").strip()
+    session, error = session_controller.control_target(request_id)
+    if error == "no_active_session":
+        return None, (
+            jsonify({"error": "There is no active playback request"}),
+            409,
+        )
+    if error == "stale_session":
+        return None, (
+            jsonify({"error": "Playback request is no longer active"}),
+            409,
+        )
+    return session, None
 
 def get_pipeline():
     global pipeline
     if pipeline is None:
-        print("[Sidecar] Initializing Kokoro Pipeline...")
-        try:
-            config_path = os.path.join(MODEL_DIR, "config.json")
-            model_path = os.path.join(MODEL_DIR, "kokoro-v1_0.pth")
-            if os.path.isfile(config_path) and os.path.isfile(model_path):
-                print("[Sidecar] Loading bundled model weights.")
-                repo_id = "hexgrad/Kokoro-82M"
-                model = KModel(repo_id=repo_id, config=config_path, model=model_path)
-                pipeline = KPipeline(lang_code='a', repo_id=repo_id, model=model)
-            else:
-                print("[Sidecar] Bundled weights not found; downloading from Hugging Face.")
-                pipeline = KPipeline(lang_code='a')
-            print("[Sidecar] Pipeline initialized successfully.")
-        except Exception as e:
-            print(f"[Sidecar] CRITICAL: Failed to initialize Pipeline: {e}")
-            raise e
+        with pipeline_lock:
+            if pipeline is None:
+                print("[Sidecar] Initializing Kokoro Pipeline...")
+                try:
+                    config_path = os.path.join(MODEL_DIR, "config.json")
+                    model_path = os.path.join(MODEL_DIR, "kokoro-v1_0.pth")
+                    if os.path.isfile(config_path) and os.path.isfile(model_path):
+                        print("[Sidecar] Loading bundled model weights.")
+                        repo_id = "hexgrad/Kokoro-82M"
+                        model = KModel(repo_id=repo_id, config=config_path, model=model_path)
+                        pipeline = KPipeline(lang_code='a', repo_id=repo_id, model=model)
+                    else:
+                        print("[Sidecar] Bundled weights not found; downloading from Hugging Face.")
+                        pipeline = KPipeline(lang_code='a')
+                    print("[Sidecar] Pipeline initialized successfully.")
+                except Exception as e:
+                    print(f"[Sidecar] CRITICAL: Failed to initialize Pipeline: {e}")
+                    raise e
     return pipeline
+
+
+def warm_pipeline():
+    """Load weights and run one tiny inference before the server reports healthy."""
+    import time
+
+    started_at = time.perf_counter()
+    warmed_pipeline = get_pipeline()
+    bundled_voice = os.path.join(MODEL_DIR, "voices", "am_fenrir.pt")
+    voice_source = bundled_voice if os.path.isfile(bundled_voice) else "am_fenrir"
+    next(warmed_pipeline("Ready.", voice=voice_source, speed=1.0))
+    elapsed_ms = round((time.perf_counter() - started_at) * 1000)
+    print(f"[Sidecar] Pipeline prewarmed in {elapsed_ms}ms.")
+
+
+def warm_speed_processor():
+    """Fail startup early if the packaged real-time DSP cannot load or process."""
+    with SonicSpeedProcessor(initial_speed=1.0) as processor:
+        processor.process(np.zeros((480, 1), dtype=np.float32))
+        processor.flush()
+    print("[Sidecar] Sonic speed DSP ready.")
 
 def cleanup_zombies():
     """ Force-kills any previous instances using a PID file. """
@@ -141,22 +200,40 @@ def cleanup_zombies():
 
 @app.route("/tts", methods=["POST"])
 def tts():
-    # Stop any previous playback immediately
-    stop_event.set()
-    pause_event.clear() # Reset pause on new request
-    sd.stop()
-    
-    p = get_pipeline()
     data = request.json or {}
     text = data.get("text", "")
+    synthesis_segments = normalize_synthesis_segments(data.get("segments"), text)
+    request_id = str(data.get("request_id") or uuid.uuid4()).strip()
     speed = float(data.get("speed", 1.0))
     voice = data.get("voice", "am_fenrir")
     bundled_voice = os.path.join(MODEL_DIR, "voices", f"{voice}.pt")
     voice_source = bundled_voice if os.path.isfile(bundled_voice) else voice
     volume = float(data.get("volume", 1.0))
     
-    if not text:
+    if not synthesis_segments:
         return jsonify({"error": "No text provided"}), 400
+
+    # Each worker captures this token. Starting another request sets only the old
+    # token, so clearing state for the new session can never revive old workers.
+    session = session_controller.begin(request_id, initial_speed=speed)
+    request_cancel_event = session.cancel_event
+    sd.stop()
+    emit_tts_event(
+        "request_received",
+        request_id,
+        textLength=sum(len(segment["spoken_text"]) for segment in synthesis_segments),
+        segmentCount=len(synthesis_segments),
+        voice=voice,
+        speed=speed,
+    )
+
+    try:
+        p = get_pipeline()
+    except Exception as e:
+        emit_tts_event("error", request_id, message=str(e), stage="engine_initialization")
+        session_controller.clear(session)
+        return jsonify({"error": "TTS engine failed to initialize", "request_id": request_id}), 500
+    emit_tts_event("engine_ready", request_id)
         
     meta = f"V:{voice}, S:{speed}, Vol:{volume}"
     if not getattr(sys, 'frozen', False):
@@ -167,150 +244,228 @@ def tts():
     else:
         print(f"[Sidecar] Synthesizing ({meta}, chars:{len(text)})")
     
-    # Small pause to let previous workers exit gracefully
-    import time
-    time.sleep(0.1)
-    stop_event.clear()
-    
     import queue
     audio_queue = queue.Queue(maxsize=10)
+    request_failed_event = threading.Event()
+
+    def put_audio_queue(item):
+        """Apply backpressure without trapping a cancelled generator thread."""
+        while not request_cancel_event.is_set():
+            try:
+                audio_queue.put(item, timeout=0.1)
+                return True
+            except queue.Full:
+                continue
+        return False
 
     def generator_worker():
         """ Thread that generates audio tensors as fast as possible. """
         try:
-            generator = p(text, voice=voice_source, speed=speed)
-            for i, (gs, ps, audio) in enumerate(generator):
-                if stop_event.is_set():
+            emit_tts_event("inference_started", request_id)
+            chunk_index = 0
+            for segment in synthesis_segments:
+                if request_cancel_event.is_set():
                     break
-                
-                # Push the raw tensor and its index into the queue
-                audio_queue.put((i, audio))
-                print(f"[Sidecar] Generated chunk {i} (queued)")
+                # The PyTorch pipeline is shared. Serialize model calls so a
+                # replacement request cannot execute concurrently with the old
+                # request while its cancellation reaches a yield boundary.
+                with inference_lock:
+                    if request_cancel_event.is_set():
+                        break
+                    generator = p(
+                        segment["spoken_text"],
+                        voice=voice_source,
+                        # Runtime speed is handled by the streaming Sonic DSP so
+                        # it can change inside already-generated speech.
+                        speed=1.0,
+                    )
+                    for gs, ps, audio in generator:
+                        if request_cancel_event.is_set():
+                            break
+
+                        # The planner bounds segments below Kokoro's token limit, so a
+                        # planned segment normally produces one engine chunk.
+                        queued = put_audio_queue(AudioChunk(
+                            index=chunk_index,
+                            audio=audio,
+                            pause_after_ms=segment["pause_after_ms"],
+                            segment_id=segment["id"],
+                        ))
+                        if not queued:
+                            break
+                        print(f"[Sidecar] Generated chunk {chunk_index} (queued)")
+                        emit_tts_event(
+                            "chunk_ready",
+                            request_id,
+                            chunkIndex=chunk_index,
+                            segmentId=segment["id"],
+                            segmentKind=segment["kind"],
+                            pauseAfterMs=segment["pause_after_ms"],
+                            sampleCount=int(audio.shape[-1]) if hasattr(audio, "shape") else len(audio),
+                        )
+                        chunk_index += 1
+                if request_cancel_event.is_set():
+                    break
             
             # Signal end of generation
-            audio_queue.put((None, None))
+            put_audio_queue(None)
         except Exception as e:
-            print(f"[STATUS] ERROR: {e}")
+            print(f"[Sidecar] Inference error: {e}")
+            request_failed_event.set()
+            emit_tts_event("error", request_id, message=str(e), stage="inference")
             import traceback
             traceback.print_exc()
-            audio_queue.put((None, None))
+            put_audio_queue(None)
 
     def playback_worker():
         """ Thread that consumes from the queue and plays audio. """
         print("[STATUS] START")
-        current_chunk = None
+
+        def emit_control_acknowledgement(event, position):
+            emit_tts_event(
+                event,
+                request_id,
+                chunkIndex=position.chunk_index,
+                sampleOffset=position.sample_offset,
+            )
+
+        def prepare_audio(chunk):
+            audio = chunk.audio
+            if hasattr(audio, "cpu"):
+                played_audio = (audio * volume).cpu().numpy().astype(np.float32)
+            else:
+                played_audio = (np.asarray(audio) * volume).astype(np.float32)
+
+            if len(played_audio.shape) == 1:
+                played_audio = played_audio.reshape(-1, 1)
+
+            pause_sample_count = int(24000 * chunk.pause_after_ms / 1000)
+            if pause_sample_count:
+                played_audio = np.concatenate([
+                    played_audio,
+                    np.zeros((pause_sample_count, 1), dtype=np.float32),
+                ], axis=0)
+
+            max_val = float(np.max(np.abs(played_audio)))
+            rms = float(np.sqrt(np.mean(played_audio**2)))
+            print(f"[Sidecar] Chunk {chunk.index} | Max: {max_val:.4f} | RMS: {rms:.4f}")
+            return played_audio
+
+        def on_first_write(chunk):
+            emit_tts_event(
+                "playback_started",
+                request_id,
+                chunkIndex=chunk.index,
+                segmentId=chunk.segment_id,
+            )
+
+        def process_speed_block(processor, audio):
+            desired_speed, speed_version = session.speed_snapshot()
+            processed = processor.process(audio, speed=desired_speed)
+            if session.acknowledge_speed(speed_version):
+                position = session.position()
+                emit_tts_event(
+                    "speed_changed",
+                    request_id,
+                    speed=desired_speed,
+                    chunkIndex=position.chunk_index,
+                    sampleOffset=position.sample_offset,
+                )
+            return processed
         
         try:
             # Open a persistent stream for the entire session
             # This fixes #9 by avoiding the startup/shutdown latency of sd.play()
-            with sd.OutputStream(samplerate=24000, channels=1, dtype='float32') as stream:
-                stream.start()
-                
-                while not stop_event.is_set():
-                    # If we don't have a chunk (or finished the last one), get the next one
-                    if current_chunk is None:
-                        try:
-                            current_chunk = audio_queue.get(timeout=1.0)
-                        except queue.Empty:
-                            if stop_event.is_set(): break
-                            continue
-                    
-                    i, audio = current_chunk
-                    if i is None: # End of stream
-                        break
-                    
-                    # Wait while paused
-                    if pause_event.is_set():
-                        stream.stop() # Suspends hardware without closing
-                        import time
-                        time.sleep(0.1)
-                        continue
-                    
-                    if not stream.active:
-                        stream.start()
-
-                    # Prepare audio
-                    if hasattr(audio, "cpu"):
-                        played_audio = (audio * volume).cpu().numpy().astype(np.float32)
-                    else:
-                        played_audio = (np.asarray(audio) * volume).astype(np.float32)
-
-                    # Ensure audio is 2D (N,1) for sounddevice
-                    if len(played_audio.shape) == 1:
-                        played_audio = played_audio.reshape(-1, 1)
-
-                    # Issue #9: For the VERY first chunk, prepend 250ms of silence 
-                    # to ensure the initial driver ramp-up doesn't clip.
-                    if i == 0:
-                        initial_silence = np.zeros((6000, 1), dtype=np.float32) # 250ms
-                        played_audio = np.concatenate([initial_silence, played_audio], axis=0)
-                    
-                    # Add a natural pause between sentences (Issue #9 follow-up)
-                    # Tightened for better flow at high speeds.
-                    inter_chunk_silence = np.zeros((4800, 1), dtype=np.float32) # 200ms
-                    played_audio = np.concatenate([played_audio, inter_chunk_silence], axis=0)
-                    
-                    max_val = float(np.max(np.abs(played_audio)))
-                    print(f"[Sidecar] Chunk {i} | Max: {max_val:.4f} | RMS: {float(np.sqrt(np.mean(played_audio**2))):.4f}")
-                    
-                    try:
-                        # Feed the stream in small buffers (50ms) so we can interrupt INSTANTLY
-                        # if the user hits Pause or Stop mid-sentence.
-                        buffer_size = 1200 # 50ms at 24000Hz
-                        interrupted = False
-                        
-                        for start_idx in range(0, len(played_audio), buffer_size):
-                            if stop_event.is_set() or pause_event.is_set():
-                                interrupted = True
-                                break
-                            
-                            end_idx = min(start_idx + buffer_size, len(played_audio))
-                            stream.write(played_audio[start_idx:end_idx])
-                        
-                        if interrupted:
-                            if pause_event.is_set():
-                                stream.stop()
-                                # Do NOT clear current_chunk; it will replay on resume
-                                print(f"[Sidecar] Paused mid-chunk {i}. Ready to replay.")
-                            continue
-
-                        # Finished chunk normally
-                        current_chunk = None
-                        audio_queue.task_done()
-                    except Exception as playback_err:
-                        print(f"[STATUS] ERROR: {playback_err}")
-                        current_chunk = None # Don't get stuck on error
+            with (
+                sd.OutputStream(samplerate=24000, channels=1, dtype='float32') as stream,
+                SonicSpeedProcessor(initial_speed=speed) as speed_processor,
+            ):
+                play_queued_audio(
+                    stream,
+                    audio_queue,
+                    session,
+                    prepare_audio=prepare_audio,
+                    # A 20ms source block becomes at most 40ms at 0.5x, keeping
+                    # pause and speed-command response comfortably sub-100ms.
+                    block_size=960,
+                    on_first_write=on_first_write,
+                    on_paused=lambda position: emit_control_acknowledgement("paused", position),
+                    on_resumed=lambda position: emit_control_acknowledgement("resumed", position),
+                    process_audio_block=lambda audio: process_speed_block(speed_processor, audio),
+                    flush_audio=speed_processor.flush,
+                    source_block_size=480,
+                )
         except Exception as e:
-            print(f"[STATUS] ERROR: {e}")
+            print(f"[Sidecar] Playback stream error: {e}")
+            request_failed_event.set()
+            emit_tts_event("error", request_id, message=str(e), stage="playback")
             
         print("[STATUS] FINISHED")
+        if (
+            not request_failed_event.is_set()
+            and session_controller.is_active(session)
+        ):
+            emit_tts_event("playback_finished", request_id)
+        session_controller.clear(session)
 
     # Start both workers
     threading.Thread(target=generator_worker, daemon=True).start()
     threading.Thread(target=playback_worker, daemon=True).start()
     
-    return jsonify({"status": "ok"})
+    return jsonify({"status": "ok", "request_id": request_id})
 
 @app.route("/stop", methods=["POST"])
 def stop():
+    data = request.get_json(silent=True) or {}
+    session, error_response = validate_control_request(data)
+    if error_response:
+        return error_response
     print("[Sidecar] Stopping playback")
-    stop_event.set()
-    pause_event.clear()
+    if session is not None:
+        session.cancel()
     sd.stop()
+    if session is not None:
+        emit_tts_event("cancelled", session.request_id)
+        session_controller.clear(session)
     return jsonify({"status": "stopped"})
 
 @app.route("/pause", methods=["POST"])
 def pause():
+    data = request.get_json(silent=True) or {}
+    session, error_response = validate_control_request(data)
+    if error_response:
+        return error_response
     print("[Sidecar] Pausing playback")
-    pause_event.set()
-    sd.stop()
-    return jsonify({"status": "paused"})
+    if session is not None:
+        session.pause()
+    return jsonify({"status": "pause_requested"})
 
 @app.route("/resume", methods=["POST"])
 def resume():
+    data = request.get_json(silent=True) or {}
+    session, error_response = validate_control_request(data)
+    if error_response:
+        return error_response
     print("[Sidecar] Resuming playback")
-    pause_event.clear()
-    return jsonify({"status": "resumed"})
+    if session is not None:
+        session.resume()
+    return jsonify({"status": "resume_requested"})
+
+@app.route("/speed", methods=["POST"])
+def set_speed():
+    data = request.get_json(silent=True) or {}
+    session, error_response = validate_control_request(data)
+    if error_response:
+        return error_response
+    if session is None:
+        return jsonify({"error": "There is no active playback request"}), 409
+    try:
+        speed = float(data.get("speed"))
+        version = session.set_speed(speed)
+    except (TypeError, ValueError) as error:
+        return jsonify({"error": str(error)}), 400
+    print(f"[Sidecar] Playback speed requested: {speed:.1f}x")
+    return jsonify({"status": "speed_requested", "speed": speed, "version": version})
 
 @app.route("/devices", methods=["GET"])
 def get_devices():
@@ -388,7 +543,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     cleanup_zombies()
-    
+
+    # Health means ready to synthesize, not merely that Flask has bound a port.
+    # This moves cold model/JIT cost into the existing splash startup phase.
+    warm_pipeline()
+    warm_speed_processor()
+
     print(f"[Sidecar] Starting Kokoro TTS server on port {args.port}")
     # Use threaded=True to ensure one hanging request doesn't block the whole server
     app.run(host="127.0.0.1", port=args.port, threaded=True)

--- a/sidecar/playback_session.py
+++ b/sidecar/playback_session.py
@@ -1,0 +1,143 @@
+"""Thread-safe lifecycle state for one TTS playback request."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import threading
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class PlaybackPosition:
+    chunk_index: Optional[int]
+    sample_offset: int
+
+
+@dataclass
+class PlaybackSession:
+    request_id: str
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    pause_event: threading.Event = field(default_factory=threading.Event)
+    _chunk_index: Optional[int] = None
+    _sample_offset: int = 0
+    _position_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _pause_acknowledged: bool = False
+    _resume_pending: bool = False
+    _playback_speed: float = 1.0
+    _speed_version: int = 0
+    _acknowledged_speed_version: int = 0
+    _control_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def cancel(self) -> None:
+        self.cancel_event.set()
+        self.pause_event.clear()
+        with self._control_lock:
+            self._resume_pending = False
+
+    def pause(self) -> None:
+        if not self.cancel_event.is_set():
+            with self._control_lock:
+                self._pause_acknowledged = False
+                self._resume_pending = False
+                self.pause_event.set()
+
+    def resume(self) -> None:
+        with self._control_lock:
+            if self.pause_event.is_set() and not self.cancel_event.is_set():
+                self._resume_pending = True
+            self.pause_event.clear()
+
+    def acknowledge_pause(self) -> bool:
+        """Return true exactly once after the stream stops for this pause."""
+        with self._control_lock:
+            if not self.pause_event.is_set() or self._pause_acknowledged:
+                return False
+            self._pause_acknowledged = True
+            return True
+
+    def acknowledge_resume(self) -> bool:
+        """Return true exactly once after the stream restarts for this resume."""
+        with self._control_lock:
+            if self.pause_event.is_set() or not self._resume_pending:
+                return False
+            self._resume_pending = False
+            self._pause_acknowledged = False
+            return True
+
+    def set_speed(self, speed: float) -> int:
+        speed = float(speed)
+        if speed < 0.5 or speed > 2.0:
+            raise ValueError("speed must be between 0.5 and 2.0")
+        with self._control_lock:
+            if speed != self._playback_speed:
+                self._playback_speed = speed
+                self._speed_version += 1
+            return self._speed_version
+
+    def speed_snapshot(self) -> tuple[float, int]:
+        with self._control_lock:
+            return self._playback_speed, self._speed_version
+
+    def acknowledge_speed(self, version: int) -> bool:
+        with self._control_lock:
+            if version <= self._acknowledged_speed_version:
+                return False
+            self._acknowledged_speed_version = version
+            return True
+
+    def set_position(self, chunk_index: int, sample_offset: int) -> None:
+        with self._position_lock:
+            self._chunk_index = chunk_index
+            self._sample_offset = max(0, sample_offset)
+
+    def clear_position(self) -> None:
+        with self._position_lock:
+            self._chunk_index = None
+            self._sample_offset = 0
+
+    def position(self) -> PlaybackPosition:
+        with self._position_lock:
+            return PlaybackPosition(self._chunk_index, self._sample_offset)
+
+
+class PlaybackSessionController:
+    """Owns the active session and prevents stale controls from crossing requests."""
+
+    def __init__(self) -> None:
+        self._active: Optional[PlaybackSession] = None
+        self._lock = threading.Lock()
+
+    def begin(self, request_id: str, initial_speed: float = 1.0) -> PlaybackSession:
+        session = PlaybackSession(request_id=request_id)
+        session.set_speed(initial_speed)
+        with self._lock:
+            if self._active is not None:
+                self._active.cancel()
+            self._active = session
+        return session
+
+    def active(self) -> Optional[PlaybackSession]:
+        with self._lock:
+            return self._active
+
+    def is_active(self, session: PlaybackSession) -> bool:
+        with self._lock:
+            return self._active is session
+
+    def clear(self, session: PlaybackSession) -> None:
+        with self._lock:
+            if self._active is session:
+                self._active = None
+
+    def control_target(
+        self,
+        request_id: str,
+    ) -> tuple[Optional[PlaybackSession], Optional[str]]:
+        """Return the active target or a stable error code for a stale control."""
+        with self._lock:
+            active = self._active
+            if request_id and active is None:
+                return None, "no_active_session"
+            if request_id and active is not None and request_id != active.request_id:
+                return None, "stale_session"
+            return active, None

--- a/sidecar/sonic_speed.py
+++ b/sidecar/sonic_speed.py
@@ -1,0 +1,162 @@
+"""Streaming, pitch-preserving speech-rate control backed by vendored Sonic."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+import platform
+import sys
+from typing import Optional
+
+import numpy as np
+
+
+MIN_PLAYBACK_SPEED = 0.5
+MAX_PLAYBACK_SPEED = 2.0
+
+
+def native_library_filename(system: Optional[str] = None) -> str:
+    system = system or platform.system()
+    if system == "Windows":
+        return "sonic_kctts.dll"
+    if system == "Darwin":
+        return "libsonic_kctts.dylib"
+    return "libsonic_kctts.so"
+
+
+def native_library_path() -> Path:
+    if getattr(sys, "frozen", False):
+        return Path(sys._MEIPASS) / "native" / native_library_filename()
+    return Path(__file__).resolve().parent / "native" / native_library_filename()
+
+
+def load_sonic_library(path: Optional[Path] = None):
+    library_path = path or native_library_path()
+    if not library_path.is_file():
+        raise RuntimeError(f"Sonic DSP library is missing: {library_path}")
+    library = ctypes.CDLL(os.fspath(library_path))
+    float_pointer = ctypes.POINTER(ctypes.c_float)
+    library.kctts_sonic_create.argtypes = [ctypes.c_int, ctypes.c_int]
+    library.kctts_sonic_create.restype = ctypes.c_void_p
+    library.kctts_sonic_destroy.argtypes = [ctypes.c_void_p]
+    library.kctts_sonic_destroy.restype = None
+    library.kctts_sonic_set_speed.argtypes = [ctypes.c_void_p, ctypes.c_float]
+    library.kctts_sonic_set_speed.restype = None
+    library.kctts_sonic_write_float.argtypes = [
+        ctypes.c_void_p,
+        float_pointer,
+        ctypes.c_int,
+    ]
+    library.kctts_sonic_write_float.restype = ctypes.c_int
+    library.kctts_sonic_read_float.argtypes = [
+        ctypes.c_void_p,
+        float_pointer,
+        ctypes.c_int,
+    ]
+    library.kctts_sonic_read_float.restype = ctypes.c_int
+    library.kctts_sonic_flush.argtypes = [ctypes.c_void_p]
+    library.kctts_sonic_flush.restype = ctypes.c_int
+    library.kctts_sonic_available.argtypes = [ctypes.c_void_p]
+    library.kctts_sonic_available.restype = ctypes.c_int
+    return library
+
+
+class SonicSpeedProcessor:
+    """Own one stateful Sonic stream for a playback session."""
+
+    def __init__(
+        self,
+        sample_rate: int = 24_000,
+        channels: int = 1,
+        initial_speed: float = 1.0,
+        library_path: Optional[Path] = None,
+    ) -> None:
+        if sample_rate <= 0 or channels <= 0:
+            raise ValueError("sample_rate and channels must be positive")
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self._library = load_sonic_library(library_path)
+        self._stream = self._library.kctts_sonic_create(sample_rate, channels)
+        if not self._stream:
+            raise RuntimeError("Sonic could not create a processing stream")
+        self._speed = 1.0
+        self.set_speed(initial_speed)
+
+    @property
+    def speed(self) -> float:
+        return self._speed
+
+    def set_speed(self, speed: float) -> None:
+        speed = float(speed)
+        if not MIN_PLAYBACK_SPEED <= speed <= MAX_PLAYBACK_SPEED:
+            raise ValueError(
+                f"speed must be between {MIN_PLAYBACK_SPEED} and {MAX_PLAYBACK_SPEED}"
+            )
+        if speed != self._speed:
+            self._library.kctts_sonic_set_speed(self._stream, speed)
+            self._speed = speed
+
+    def process(self, audio, speed: Optional[float] = None) -> np.ndarray:
+        if self._stream is None:
+            raise RuntimeError("Sonic stream is closed")
+        if speed is not None:
+            self.set_speed(speed)
+        frames = np.asarray(audio, dtype=np.float32)
+        if frames.ndim == 1:
+            frames = frames.reshape(-1, 1)
+        if frames.ndim != 2 or frames.shape[1] != self.channels:
+            raise ValueError(f"audio must have shape (frames, {self.channels})")
+        frames = np.ascontiguousarray(frames)
+        pointer = frames.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+        if not self._library.kctts_sonic_write_float(
+            self._stream,
+            pointer,
+            frames.shape[0],
+        ):
+            raise RuntimeError("Sonic rejected an audio buffer")
+        return self._drain()
+
+    def flush(self) -> np.ndarray:
+        if self._stream is None:
+            return np.empty((0, self.channels), dtype=np.float32)
+        if not self._library.kctts_sonic_flush(self._stream):
+            raise RuntimeError("Sonic failed to flush buffered audio")
+        return self._drain()
+
+    def _drain(self) -> np.ndarray:
+        chunks = []
+        while True:
+            available = self._library.kctts_sonic_available(self._stream)
+            if available <= 0:
+                break
+            output = np.empty((available, self.channels), dtype=np.float32)
+            pointer = output.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+            received = self._library.kctts_sonic_read_float(
+                self._stream,
+                pointer,
+                available,
+            )
+            if received <= 0:
+                break
+            chunks.append(output[:received].copy())
+        if not chunks:
+            return np.empty((0, self.channels), dtype=np.float32)
+        return np.concatenate(chunks, axis=0)
+
+    def close(self) -> None:
+        if self._stream is not None:
+            self._library.kctts_sonic_destroy(self._stream)
+            self._stream = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/sidecar/test_audio_playback.py
+++ b/sidecar/test_audio_playback.py
@@ -1,0 +1,284 @@
+import unittest
+from queue import Queue
+import threading
+
+from sidecar.audio_playback import AudioChunk, play_queued_audio, write_audio_blocks
+from sidecar.playback_session import PlaybackSessionController
+
+
+class FakeStream:
+    def __init__(self):
+        self.blocks = []
+
+    def write(self, block):
+        self.blocks.append(list(block))
+
+
+class FakePersistentStream(FakeStream):
+    def __init__(self, after_write=None):
+        super().__init__()
+        self.active = False
+        self.start_count = 0
+        self.stop_count = 0
+        self.after_write = after_write
+
+    def start(self):
+        self.active = True
+        self.start_count += 1
+
+    def stop(self):
+        self.active = False
+        self.stop_count += 1
+
+    def write(self, block):
+        super().write(block)
+        if self.after_write is not None:
+            self.after_write(self)
+
+
+class AudioPlaybackTests(unittest.TestCase):
+    def test_writes_all_blocks_and_reports_completion(self):
+        stream = FakeStream()
+
+        result = write_audio_blocks(
+            stream,
+            list(range(10)),
+            start_offset=0,
+            block_size=4,
+            should_interrupt=lambda: False,
+        )
+
+        self.assertTrue(result.completed)
+        self.assertEqual(result.next_offset, 10)
+        self.assertEqual(stream.blocks, [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
+
+    def test_resume_starts_at_first_unwritten_sample(self):
+        stream = FakeStream()
+
+        paused = write_audio_blocks(
+            stream,
+            list(range(12)),
+            start_offset=0,
+            block_size=4,
+            should_interrupt=lambda: len(stream.blocks) == 2,
+        )
+        resumed = write_audio_blocks(
+            stream,
+            list(range(12)),
+            start_offset=paused.next_offset,
+            block_size=4,
+            should_interrupt=lambda: False,
+        )
+
+        self.assertFalse(paused.completed)
+        self.assertEqual(paused.next_offset, 8)
+        self.assertTrue(resumed.completed)
+        self.assertEqual(resumed.next_offset, 12)
+        self.assertEqual(
+            [sample for block in stream.blocks for sample in block],
+            list(range(12)),
+        )
+
+    def test_calls_before_write_with_exact_ranges(self):
+        ranges = []
+        successful_ranges = []
+
+        write_audio_blocks(
+            FakeStream(),
+            list(range(5)),
+            start_offset=2,
+            block_size=2,
+            should_interrupt=lambda: False,
+            before_write=lambda start, end: ranges.append((start, end)),
+            after_write=lambda start, end: successful_ranges.append((start, end)),
+        )
+
+        self.assertEqual(ranges, [(2, 4), (4, 5)])
+        self.assertEqual(successful_ranges, [(2, 4), (4, 5)])
+
+    def test_does_not_report_a_failed_write_as_successful(self):
+        successful_ranges = []
+
+        class FailingStream:
+            def write(self, block):
+                raise RuntimeError("device disconnected")
+
+        with self.assertRaises(RuntimeError):
+            write_audio_blocks(
+                FailingStream(),
+                [1, 2],
+                start_offset=0,
+                block_size=2,
+                should_interrupt=lambda: False,
+                after_write=lambda start, end: successful_ranges.append((start, end)),
+            )
+
+        self.assertEqual(successful_ranges, [])
+
+    def test_rejects_invalid_offsets_and_block_sizes(self):
+        with self.assertRaises(ValueError):
+            write_audio_blocks(
+                FakeStream(),
+                [1, 2],
+                start_offset=-1,
+                block_size=1,
+                should_interrupt=lambda: False,
+            )
+        with self.assertRaises(ValueError):
+            write_audio_blocks(
+                FakeStream(),
+                [1, 2],
+                start_offset=0,
+                block_size=0,
+                should_interrupt=lambda: False,
+            )
+
+    def test_queue_player_preserves_multi_chunk_order(self):
+        audio_queue = Queue()
+        audio_queue.put(AudioChunk(0, [0, 1, 2], 0, "segment-0"))
+        audio_queue.put(AudioChunk(1, [3, 4, 5], 0, "segment-1"))
+        audio_queue.put(None)
+        session = PlaybackSessionController().begin("request")
+        first_writes = []
+        stream = FakePersistentStream()
+
+        result = play_queued_audio(
+            stream,
+            audio_queue,
+            session,
+            prepare_audio=lambda chunk: chunk.audio,
+            block_size=2,
+            on_first_write=lambda chunk: first_writes.append(chunk.index),
+        )
+
+        self.assertFalse(result.cancelled)
+        self.assertEqual(result.completed_chunks, 2)
+        self.assertEqual(
+            [sample for block in stream.blocks for sample in block],
+            [0, 1, 2, 3, 4, 5],
+        )
+        self.assertEqual(first_writes, [0])
+        self.assertEqual(session.position().sample_offset, 0)
+
+    def test_queue_player_pauses_and_resumes_at_exact_unwritten_sample(self):
+        audio_queue = Queue()
+        audio_queue.put(AudioChunk(0, list(range(12)), 0, "segment-0"))
+        audio_queue.put(None)
+        session = PlaybackSessionController().begin("request")
+        paused_positions = []
+        resumed_positions = []
+
+        def pause_after_two_blocks(stream):
+            if len(stream.blocks) == 2:
+                session.pause()
+
+        stream = FakePersistentStream(after_write=pause_after_two_blocks)
+
+        def resume_after_ack(position):
+            paused_positions.append(position.sample_offset)
+            session.resume()
+
+        result = play_queued_audio(
+            stream,
+            audio_queue,
+            session,
+            prepare_audio=lambda chunk: chunk.audio,
+            block_size=4,
+            on_paused=resume_after_ack,
+            on_resumed=lambda position: resumed_positions.append(position.sample_offset),
+        )
+
+        self.assertFalse(result.cancelled)
+        self.assertEqual(paused_positions, [8])
+        self.assertEqual(resumed_positions, [8])
+        self.assertEqual(
+            [sample for block in stream.blocks for sample in block],
+            list(range(12)),
+        )
+
+    def test_queue_player_cancels_without_writing_future_chunks(self):
+        audio_queue = Queue()
+        audio_queue.put(AudioChunk(0, list(range(8)), 0, "segment-0"))
+        audio_queue.put(AudioChunk(1, list(range(8, 16)), 0, "segment-1"))
+        audio_queue.put(None)
+        session = PlaybackSessionController().begin("request")
+
+        def cancel_after_first_block(stream):
+            if len(stream.blocks) == 1:
+                session.cancel()
+
+        stream = FakePersistentStream(after_write=cancel_after_first_block)
+        result = play_queued_audio(
+            stream,
+            audio_queue,
+            session,
+            prepare_audio=lambda chunk: chunk.audio,
+            block_size=4,
+        )
+
+        self.assertTrue(result.cancelled)
+        self.assertEqual(result.completed_chunks, 0)
+        self.assertEqual(stream.blocks, [[0, 1, 2, 3]])
+
+    def test_bounded_queue_drains_a_long_ordered_session_without_deadlock(self):
+        audio_queue = Queue(maxsize=3)
+        session = PlaybackSessionController().begin("long-request")
+        chunk_count = 500
+
+        def produce():
+            for index in range(chunk_count):
+                audio_queue.put(AudioChunk(index, [index], 0, f"segment-{index}"))
+            audio_queue.put(None)
+
+        producer = threading.Thread(target=produce)
+        producer.start()
+        stream = FakePersistentStream()
+        result = play_queued_audio(
+            stream,
+            audio_queue,
+            session,
+            prepare_audio=lambda chunk: chunk.audio,
+            block_size=1,
+        )
+        producer.join(timeout=1)
+
+        self.assertFalse(producer.is_alive())
+        self.assertEqual(result.completed_chunks, chunk_count)
+        self.assertEqual([block[0] for block in stream.blocks], list(range(chunk_count)))
+        self.assertEqual(audio_queue.qsize(), 0)
+
+    def test_queue_player_streams_processed_blocks_and_flushes_tail(self):
+        audio_queue = Queue()
+        audio_queue.put(AudioChunk(0, list(range(6)), 0, "segment-0"))
+        audio_queue.put(None)
+        session = PlaybackSessionController().begin("processed-request")
+        stream = FakePersistentStream()
+        processed_inputs = []
+
+        def process(block):
+            values = list(block)
+            processed_inputs.append(values)
+            return [value for value in values for _ in range(2)]
+
+        result = play_queued_audio(
+            stream,
+            audio_queue,
+            session,
+            prepare_audio=lambda chunk: chunk.audio,
+            block_size=4,
+            process_audio_block=process,
+            flush_audio=lambda: [99, 100],
+            source_block_size=2,
+        )
+
+        self.assertEqual(processed_inputs, [[0, 1], [2, 3], [4, 5]])
+        self.assertEqual(
+            [sample for block in stream.blocks for sample in block],
+            [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 99, 100],
+        )
+        self.assertEqual(result.completed_chunks, 1)
+        self.assertFalse(result.cancelled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sidecar/test_playback_session.py
+++ b/sidecar/test_playback_session.py
@@ -1,0 +1,97 @@
+import threading
+import unittest
+
+try:
+    from .playback_session import PlaybackSessionController
+except ImportError:
+    from playback_session import PlaybackSessionController
+
+
+class PlaybackSessionControllerTests(unittest.TestCase):
+    def test_new_session_cancels_only_the_previous_session(self):
+        controller = PlaybackSessionController()
+        previous = controller.begin("previous")
+        current = controller.begin("current")
+
+        self.assertTrue(previous.cancel_event.is_set())
+        self.assertFalse(current.cancel_event.is_set())
+        self.assertIs(controller.active(), current)
+
+    def test_stale_clear_cannot_remove_current_session(self):
+        controller = PlaybackSessionController()
+        stale = controller.begin("stale")
+        current = controller.begin("current")
+
+        controller.clear(stale)
+
+        self.assertIs(controller.active(), current)
+
+    def test_controls_and_position_are_owned_by_one_session(self):
+        controller = PlaybackSessionController()
+        session = controller.begin("request")
+
+        session.set_position(chunk_index=3, sample_offset=4812)
+        session.pause()
+        self.assertTrue(session.pause_event.is_set())
+        self.assertTrue(session.acknowledge_pause())
+        self.assertFalse(session.acknowledge_pause())
+        self.assertEqual(session.position().chunk_index, 3)
+        self.assertEqual(session.position().sample_offset, 4812)
+
+        session.resume()
+        self.assertFalse(session.pause_event.is_set())
+        self.assertTrue(session.acknowledge_resume())
+        self.assertFalse(session.acknowledge_resume())
+        session.clear_position()
+        self.assertIsNone(session.position().chunk_index)
+        self.assertEqual(session.position().sample_offset, 0)
+
+    def test_stale_and_missing_control_ids_are_rejected(self):
+        controller = PlaybackSessionController()
+        _, error = controller.control_target("missing")
+        self.assertEqual(error, "no_active_session")
+
+        current = controller.begin("current")
+        target, error = controller.control_target("stale")
+        self.assertIsNone(target)
+        self.assertEqual(error, "stale_session")
+        self.assertIs(controller.control_target("current")[0], current)
+
+    def test_speed_versions_are_acknowledged_once(self):
+        session = PlaybackSessionController().begin("request", initial_speed=1.2)
+        speed, version = session.speed_snapshot()
+        self.assertEqual(speed, 1.2)
+        self.assertEqual(version, 1)
+        self.assertTrue(session.acknowledge_speed(version))
+        self.assertFalse(session.acknowledge_speed(version))
+
+        next_version = session.set_speed(1.8)
+        self.assertGreater(next_version, version)
+        self.assertEqual(session.speed_snapshot(), (1.8, next_version))
+        with self.assertRaises(ValueError):
+            session.set_speed(2.1)
+
+    def test_concurrent_replacements_leave_one_uncancelled_session(self):
+        controller = PlaybackSessionController()
+        sessions = []
+        sessions_lock = threading.Lock()
+
+        def replace(index):
+            session = controller.begin(f"request-{index}")
+            with sessions_lock:
+                sessions.append(session)
+
+        threads = [threading.Thread(target=replace, args=(index,)) for index in range(50)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        active = controller.active()
+        self.assertIsNotNone(active)
+        self.assertEqual(sum(not session.cancel_event.is_set() for session in sessions), 1)
+        self.assertIs(next(session for session in sessions if not session.cancel_event.is_set()), active)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sidecar/test_sonic_speed.py
+++ b/sidecar/test_sonic_speed.py
@@ -1,0 +1,58 @@
+import unittest
+
+import numpy as np
+
+from sidecar.sonic_speed import SonicSpeedProcessor, native_library_path
+
+
+@unittest.skipUnless(native_library_path().is_file(), "Sonic DSP must be built first")
+class SonicSpeedProcessorTests(unittest.TestCase):
+    def test_preserves_pitch_while_changing_duration(self):
+        sample_rate = 24_000
+        source = np.sin(
+            2 * np.pi * 220 * np.arange(sample_rate * 2) / sample_rate
+        ).astype(np.float32).reshape(-1, 1)
+
+        # Keep the recommended 0.75x-1.5x listening range covered as well as
+        # the advanced range endpoints.
+        for speed in (0.5, 0.75, 1.0, 1.5, 2.0):
+            with self.subTest(speed=speed):
+                with SonicSpeedProcessor(initial_speed=speed) as processor:
+                    chunks = [
+                        processor.process(source[index:index + 480])
+                        for index in range(0, len(source), 480)
+                    ]
+                    chunks.append(processor.flush())
+                output = np.concatenate(chunks, axis=0).reshape(-1)
+                expected = len(source) / speed
+                self.assertLess(abs(len(output) - expected), sample_rate * 0.03)
+
+                core = output[2000:-2000]
+                crossings = np.flatnonzero((core[:-1] <= 0) & (core[1:] > 0))
+                estimated_pitch = sample_rate / np.mean(np.diff(crossings))
+                self.assertAlmostEqual(estimated_pitch, 220, delta=1)
+
+    def test_speed_change_affects_the_next_twenty_millisecond_buffer(self):
+        source = np.zeros((480, 1), dtype=np.float32)
+        with SonicSpeedProcessor(initial_speed=1.0) as processor:
+            for _ in range(10):
+                processor.process(source)
+            first_fast_output = processor.process(source, speed=2.0)
+            second_fast_output = processor.process(source)
+
+        # Sonic may retain the first changed buffer while finding a pitch period,
+        # but produces accelerated output no later than the following 20ms input.
+        self.assertLessEqual(len(first_fast_output), 480)
+        self.assertGreater(len(second_fast_output), 0)
+        self.assertLess(len(second_fast_output), 360)
+
+    def test_rejects_out_of_range_speed(self):
+        with SonicSpeedProcessor() as processor:
+            with self.assertRaises(ValueError):
+                processor.set_speed(0.4)
+            with self.assertRaises(ValueError):
+                processor.set_speed(2.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sidecar/test_tts_protocol.py
+++ b/sidecar/test_tts_protocol.py
@@ -1,0 +1,78 @@
+import json
+import unittest
+
+from sidecar.tts_protocol import (
+    EVENT_PREFIX,
+    EVENT_SCHEMA_VERSION,
+    create_tts_event,
+    encode_tts_event,
+    normalize_synthesis_segments,
+)
+
+
+class TtsProtocolTests(unittest.TestCase):
+    def test_creates_versioned_event_with_data(self):
+        event = create_tts_event(
+            "chunk_ready",
+            "request-123",
+            timestamp_ms=42,
+            chunkIndex=3,
+        )
+
+        self.assertEqual(
+            event,
+            {
+                "schemaVersion": EVENT_SCHEMA_VERSION,
+                "requestId": "request-123",
+                "event": "chunk_ready",
+                "timestampMs": 42,
+                "data": {"chunkIndex": 3},
+            },
+        )
+
+    def test_encodes_exactly_one_prefixed_json_line(self):
+        line = encode_tts_event("request_received", "request-123", textLength=18)
+
+        self.assertTrue(line.startswith(EVENT_PREFIX))
+        self.assertNotIn("\n", line)
+        payload = json.loads(line.removeprefix(EVENT_PREFIX))
+        self.assertEqual(payload["requestId"], "request-123")
+        self.assertEqual(payload["data"]["textLength"], 18)
+
+    def test_rejects_missing_identity_fields(self):
+        with self.assertRaises(ValueError):
+            create_tts_event("", "request-123")
+        with self.assertRaises(ValueError):
+            create_tts_event("request_received", "")
+
+    def test_normalizes_model_facing_speech_segments(self):
+        segments = normalize_synthesis_segments(
+            [
+                {
+                    "id": "heading-1",
+                    "kind": "heading",
+                    "spokenText": "  A useful heading  ",
+                    "pauseAfterMs": 550,
+                    "sourceText": "## A useful heading",
+                },
+                {"id": "code-1", "kind": "code", "spokenText": ""},
+                {"id": "unsafe", "spokenText": "Bounded pause", "pauseAfterMs": 99_999},
+            ],
+            "unused fallback",
+        )
+
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[0]["spoken_text"], "A useful heading")
+        self.assertEqual(segments[0]["pause_after_ms"], 550)
+        self.assertNotIn("sourceText", segments[0])
+        self.assertEqual(segments[1]["pause_after_ms"], 2_000)
+
+    def test_falls_back_for_clients_without_a_speech_plan(self):
+        segments = normalize_synthesis_segments(None, " Legacy text ")
+
+        self.assertEqual(segments[0]["spoken_text"], "Legacy text")
+        self.assertEqual(segments[0]["pause_after_ms"], 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sidecar/tts_protocol.py
+++ b/sidecar/tts_protocol.py
@@ -1,0 +1,107 @@
+"""Structured lifecycle events shared by the TTS sidecar and its tests.
+
+The sidecar still writes human-readable diagnostics to stdout. Lifecycle events
+use a dedicated prefix followed by compact JSON so the Rust process manager can
+forward them without inferring application state from log wording.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+
+EVENT_PREFIX = "[TTS_EVENT] "
+EVENT_SCHEMA_VERSION = 1
+DEFAULT_SEGMENT_PAUSE_MS = 200
+MAX_SEGMENT_PAUSE_MS = 2_000
+
+
+def create_tts_event(
+    event: str,
+    request_id: str,
+    *,
+    timestamp_ms: int | None = None,
+    **data: Any,
+) -> dict[str, Any]:
+    """Create a validated, JSON-serializable TTS lifecycle event."""
+
+    normalized_event = event.strip()
+    normalized_request_id = request_id.strip()
+    if not normalized_event:
+        raise ValueError("event must not be empty")
+    if not normalized_request_id:
+        raise ValueError("request_id must not be empty")
+
+    return {
+        "schemaVersion": EVENT_SCHEMA_VERSION,
+        "requestId": normalized_request_id,
+        "event": normalized_event,
+        "timestampMs": timestamp_ms if timestamp_ms is not None else time.time_ns() // 1_000_000,
+        "data": data,
+    }
+
+
+def encode_tts_event(event: str, request_id: str, **data: Any) -> str:
+    """Encode an event as one stdout-safe protocol line."""
+
+    payload = create_tts_event(event, request_id, **data)
+    return EVENT_PREFIX + json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def normalize_synthesis_segments(
+    raw_segments: Any,
+    fallback_text: str,
+) -> list[dict[str, Any]]:
+    """Validate the model-facing subset of a frontend speech plan.
+
+    Empty segments (currently fenced code) remain available to the frontend for
+    source mapping but are not sent to the model. Old clients fall back to one
+    segment with the v0.6 pause duration.
+    """
+
+    normalized = []
+    if isinstance(raw_segments, list):
+        for index, raw_segment in enumerate(raw_segments):
+            if not isinstance(raw_segment, dict):
+                continue
+            spoken_text = str(
+                raw_segment.get("spokenText")
+                or raw_segment.get("spoken_text")
+                or ""
+            ).strip()
+            if not spoken_text:
+                continue
+            raw_pause = raw_segment.get(
+                "pauseAfterMs",
+                raw_segment.get("pause_after_ms", DEFAULT_SEGMENT_PAUSE_MS),
+            )
+            try:
+                pause_after_ms = int(raw_pause)
+            except (TypeError, ValueError):
+                pause_after_ms = DEFAULT_SEGMENT_PAUSE_MS
+            pause_after_ms = max(0, min(pause_after_ms, MAX_SEGMENT_PAUSE_MS))
+            normalized.append(
+                {
+                    "id": str(raw_segment.get("id") or f"segment-{index}"),
+                    "kind": str(raw_segment.get("kind") or "paragraph"),
+                    "spoken_text": spoken_text,
+                    "pause_after_ms": pause_after_ms,
+                }
+            )
+
+    if normalized:
+        return normalized
+
+    fallback_text = str(fallback_text or "").strip()
+    if not fallback_text:
+        return []
+    return [
+        {
+            "id": "segment-0",
+            "kind": "paragraph",
+            "spoken_text": fallback_text,
+            "pause_after_ms": DEFAULT_SEGMENT_PAUSE_MS,
+        }
+    ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,8 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
+ "arboard",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.6.3"
+version = "0.7.0"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"
@@ -27,3 +27,4 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 tauri-plugin-log = "2.8.0"
+arboard = { version = "3.6.1", default-features = false }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,6 @@ use tauri::{
     AppHandle, Emitter, Manager, RunEvent, WebviewUrl, WebviewWindowBuilder,
 };
 
-
 mod sidecar;
 
 use sidecar::SidecarManager;
@@ -16,6 +15,30 @@ pub struct AppState {
     pub tray: Mutex<Option<TrayIcon>>,
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ClipboardPayload {
+    text: Option<String>,
+    html: Option<String>,
+}
+
+#[tauri::command]
+async fn read_clipboard_payload() -> Result<ClipboardPayload, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let mut clipboard = arboard::Clipboard::new().map_err(|error| error.to_string())?;
+        let text = clipboard.get_text().ok();
+        let html = clipboard.get().html().ok();
+
+        if text.is_none() && html.is_none() {
+            return Err("The clipboard does not contain readable text".into());
+        }
+
+        Ok(ClipboardPayload { text, html })
+    })
+    .await
+    .map_err(|error| format!("Clipboard read task failed: {error}"))?
+}
+
 // ─── Tauri Commands ───────────────────────────────────────────────────────────
 
 #[tauri::command]
@@ -24,6 +47,8 @@ async fn send_to_tts(
     speed: f32,
     voice: String,
     volume: f32,
+    request_id: String,
+    segments: serde_json::Value,
 ) -> Result<String, String> {
     let client = reqwest::Client::new();
     let payload = serde_json::json!({
@@ -31,6 +56,8 @@ async fn send_to_tts(
         "speed": speed,
         "voice": voice,
         "volume": volume,
+        "request_id": request_id,
+        "segments": segments,
     });
 
     let res = client
@@ -41,38 +68,61 @@ async fn send_to_tts(
         .map_err(|e| format!("TTS request failed: {e}"))?;
 
     if res.status().is_success() {
-        Ok("ok".into())
+        Ok(request_id)
     } else {
         Err(format!("TTS server returned {}", res.status()))
     }
 }
 
-#[tauri::command]
-async fn pause_tts() -> Result<(), String> {
+async fn post_playback_control(path: &str, request_id: String) -> Result<(), String> {
     let client = reqwest::Client::new();
-    let _ = client.post("http://127.0.0.1:8790/pause")
+    let res = client
+        .post(format!("http://127.0.0.1:8790/{path}"))
+        .json(&serde_json::json!({ "request_id": request_id }))
         .send()
         .await
         .map_err(|e| e.to_string())?;
-    Ok(())
+
+    if res.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!("Playback control returned {}", res.status()))
+    }
 }
 
 #[tauri::command]
-async fn resume_tts() -> Result<(), String> {
+async fn pause_tts(request_id: String) -> Result<(), String> {
+    post_playback_control("pause", request_id).await
+}
+
+#[tauri::command]
+async fn resume_tts(request_id: String) -> Result<(), String> {
+    post_playback_control("resume", request_id).await
+}
+
+#[tauri::command]
+async fn set_tts_speed(request_id: String, speed: f32) -> Result<(), String> {
+    if !(0.5..=2.0).contains(&speed) {
+        return Err("Playback speed must be between 0.5 and 2.0".into());
+    }
     let client = reqwest::Client::new();
-    let _ = client.post("http://127.0.0.1:8790/resume")
+    let res = client
+        .post("http://127.0.0.1:8790/speed")
+        .json(&serde_json::json!({ "request_id": request_id, "speed": speed }))
         .send()
         .await
-        .map_err(|e| e.to_string())?;
-    Ok(())
+        .map_err(|e| format!("Speed request failed: {e}"))?;
+
+    if res.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!("Speed control returned {}", res.status()))
+    }
 }
 
 #[tauri::command]
-async fn stop_tts() -> Result<String, String> {
-    let client = reqwest::Client::new();
-    client
-        .post("http://127.0.0.1:8790/stop")
-        .send()
+async fn stop_tts(request_id: String) -> Result<String, String> {
+    post_playback_control("stop", request_id)
         .await
         .map_err(|e| format!("Stop request failed: {e}"))?;
     Ok("stopped".into())
@@ -86,7 +136,7 @@ async fn get_audio_devices() -> Result<serde_json::Value, String> {
         .send()
         .await
         .map_err(|e| format!("Failed to get devices: {e}"))?;
-        
+
     let json: serde_json::Value = res.json().await.map_err(|e| e.to_string())?;
     Ok(json)
 }
@@ -101,7 +151,7 @@ async fn set_audio_device(id: i32) -> Result<serde_json::Value, String> {
         .send()
         .await
         .map_err(|e| format!("Failed to set device: {e}"))?;
-        
+
     let json: serde_json::Value = res.json().await.map_err(|e| e.to_string())?;
     Ok(json)
 }
@@ -129,7 +179,8 @@ async fn get_sidecar_status(state: tauri::State<'_, AppState>) -> Result<String,
 #[tauri::command]
 async fn get_sidecar_log_path(state: tauri::State<'_, AppState>) -> Result<String, String> {
     let mgr = state.sidecar.lock().unwrap();
-    Ok(mgr.log_path
+    Ok(mgr
+        .log_path
         .as_ref()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default())
@@ -148,10 +199,13 @@ async fn ensure_reader_visible(app: AppHandle) -> Result<(), String> {
         if !is_visible {
             // Move to cursor and show
             if let Ok(cursor_pos) = app.cursor_position() {
-                let size = win.inner_size().unwrap_or(tauri::PhysicalSize { width: 320, height: 140 });
+                let size = win.inner_size().unwrap_or(tauri::PhysicalSize {
+                    width: 320,
+                    height: 140,
+                });
                 let x = (cursor_pos.x - (size.width as f64 / 2.0)) as i32;
                 let y = (cursor_pos.y - (size.height as f64 / 2.0)) as i32;
-                
+
                 win.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x, y }))
                     .map_err(|e| e.to_string())?;
             }
@@ -173,14 +227,17 @@ async fn hide_reader_window(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-
-
 fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
     let read_clipboard_item =
         MenuItem::with_id(app, "read_clipboard", "Read Clipboard", true, None::<&str>)?;
     let settings_item = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
-    let updates_item =
-        MenuItem::with_id(app, "check_updates", "Check for Updates", true, None::<&str>)?;
+    let updates_item = MenuItem::with_id(
+        app,
+        "check_updates",
+        "Check for Updates",
+        true,
+        None::<&str>,
+    )?;
     let tutorial_item = MenuItem::with_id(app, "tutorial", "Tutorial", true, None::<&str>)?;
     let quit_item = MenuItem::with_id(app, "quit", "Exit", true, None::<&str>)?;
 
@@ -218,16 +275,12 @@ fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
                     let _ = win.show();
                     let _ = win.set_focus();
                 } else {
-                    let _ = WebviewWindowBuilder::new(
-                        app,
-                        "settings",
-                        WebviewUrl::App("/".into()),
-                    )
-                    .title("Kokoro TTS — Settings")
-                    .inner_size(480.0, 600.0)
-                    .resizable(false)
-                    .center()
-                    .build();
+                    let _ = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("/".into()))
+                        .title("Kokoro TTS — Settings")
+                        .inner_size(480.0, 600.0)
+                        .resizable(false)
+                        .center()
+                        .build();
                 }
             }
             "check_updates" => {
@@ -238,17 +291,13 @@ fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
                     let _ = win.show();
                     let _ = win.set_focus();
                 } else {
-                    let _ = WebviewWindowBuilder::new(
-                        app,
-                        "tutorial",
-                        WebviewUrl::App("/".into()),
-                    )
-                    .title("Welcome to Kokoro TTS")
-                    .inner_size(520.0, 480.0)
-                    .resizable(false)
-                    .center()
-                    .decorations(false)
-                    .build();
+                    let _ = WebviewWindowBuilder::new(app, "tutorial", WebviewUrl::App("/".into()))
+                        .title("Welcome to Kokoro TTS")
+                        .inner_size(520.0, 480.0)
+                        .resizable(false)
+                        .center()
+                        .decorations(false)
+                        .build();
                 }
             }
             "quit" => {
@@ -281,16 +330,14 @@ pub fn run() {
     // If the app is already running, focus the existing instance and exit.
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_single_instance::init(
-            |app, _args, _cwd| {
-                // When a second instance is launched, just show the settings window
-                // of the already-running instance so the user knows it's alive.
-                if let Some(win) = app.get_webview_window("settings") {
-                    let _ = win.show();
-                    let _ = win.set_focus();
-                }
-            },
-        ));
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // When a second instance is launched, just show the settings window
+            // of the already-running instance so the user knows it's alive.
+            if let Some(win) = app.get_webview_window("settings") {
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+        }));
     }
 
     let builder = builder
@@ -306,9 +353,11 @@ pub fn run() {
             tray: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![
+            read_clipboard_payload,
             send_to_tts,
             pause_tts,
             resume_tts,
+            set_tts_speed,
             stop_tts,
             ensure_reader_visible,
             hide_reader_window,
@@ -345,10 +394,13 @@ pub fn run() {
                     })
                     .build(),
             )?;
-            app.global_shortcut().register(shortcut).map_err(|e| {
-                eprintln!("[Kokoro] Failed to register shortcut: {e}");
-                e
-            }).ok();
+            app.global_shortcut()
+                .register(shortcut)
+                .map_err(|e| {
+                    eprintln!("[Kokoro] Failed to register shortcut: {e}");
+                    e
+                })
+                .ok();
 
             // ── Background Clipboard Poller ──────────────────────────────────────────
             // Monitors for any global clipboard change without intercepting shortcuts.
@@ -357,13 +409,18 @@ pub fn run() {
             let handle_for_polling = handle.clone();
             tauri::async_runtime::spawn(async move {
                 // Initialize with current clipboard content to avoid flash on startup
-                let mut last_clipboard = handle_for_polling.clipboard().read_text().unwrap_or_default();
+                let mut last_clipboard = handle_for_polling
+                    .clipboard()
+                    .read_text()
+                    .unwrap_or_default();
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
                     if let Ok(current) = handle_for_polling.clipboard().read_text() {
                         if !current.is_empty() && current != last_clipboard {
                             // Only emit if the reader widget is actually open
-                            let is_visible = if let Some(win) = handle_for_polling.get_webview_window("reader") {
+                            let is_visible = if let Some(win) =
+                                handle_for_polling.get_webview_window("reader")
+                            {
                                 win.is_visible().unwrap_or(false)
                             } else {
                                 false

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -1,8 +1,27 @@
-use std::sync::{Arc, Mutex};
+use serde::{Deserialize, Serialize};
 use std::io::Write;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_shell::{process::CommandChild, ShellExt};
-use std::time::Duration;
+
+const TTS_EVENT_PREFIX: &str = "[TTS_EVENT] ";
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TtsEvent {
+    schema_version: u8,
+    request_id: String,
+    event: String,
+    timestamp_ms: u64,
+    #[serde(default)]
+    data: serde_json::Value,
+}
+
+fn parse_tts_event(line: &str) -> Option<TtsEvent> {
+    let payload = line.trim().strip_prefix(TTS_EVENT_PREFIX)?;
+    serde_json::from_str(payload).ok()
+}
 
 /// Manages the lifecycle of the Kokoro TTS sidecar process.
 ///
@@ -18,7 +37,7 @@ pub struct SidecarManager {
 
 impl SidecarManager {
     pub fn new() -> Self {
-        Self { 
+        Self {
             child: None,
             status: Arc::new(Mutex::new("disconnected".into())),
             log_path: None,
@@ -37,7 +56,10 @@ impl SidecarManager {
 
         // ─── Open sidecar log file ───
         // All sidecar stdout/stderr is captured here so users can diagnose errors.
-        let log_dir = app.path().app_log_dir().unwrap_or_else(|_| std::env::temp_dir());
+        let log_dir = app
+            .path()
+            .app_log_dir()
+            .unwrap_or_else(|_| std::env::temp_dir());
         let _ = std::fs::create_dir_all(&log_dir);
         let log_path = log_dir.join("kokoro-sidecar.log");
         let log_file = std::fs::OpenOptions::new()
@@ -64,12 +86,12 @@ impl SidecarManager {
             let _ = std::process::Command::new("taskkill")
                 .args(["/F", "/IM", "kokoro.exe", "/T"])
                 .output();
-                
+
             // Kill anything holding port 8790 (zombie python.exe from dev mode)
             let _ = std::process::Command::new("powershell")
                 .args(["-Command", "Get-NetTCPConnection -LocalPort 8790 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess | ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }"])
                 .output();
-            
+
             // Brief pause to let the port fully release
             std::thread::sleep(Duration::from_millis(200));
         }
@@ -86,12 +108,12 @@ impl SidecarManager {
             let _ = std::process::Command::new("pkill")
                 .args(["-f", "kokoro-aarch64-apple-darwin"])
                 .output();
-                
+
             // Forcefully free port 8790
             let _ = std::process::Command::new("sh")
                 .args(["-c", "lsof -ti:8790 | xargs kill -9 2>/dev/null"])
                 .output();
-                
+
             std::thread::sleep(Duration::from_millis(200));
         }
 
@@ -104,68 +126,90 @@ impl SidecarManager {
         println!("[Kokoro] Attempting to spawn sidecar...");
 
         // ─── Development vs Production Spawning ───
-        
+
         let (mut rx, child) = if cfg!(debug_assertions) {
             println!("[Kokoro] DEBUG MODE: Spawning sidecar from source using venv...");
-            
+
             // Resolve project root robustly
-            let mut project_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-            
+            let mut project_root =
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+
             // If we are currently in src-tauri, go up one level
             if project_root.ends_with("src-tauri") {
                 project_root = project_root.parent().unwrap().to_path_buf();
             }
 
             let mut python_path = if cfg!(target_os = "windows") {
-                project_root.join(".sidecar-venv").join("Scripts").join("python.exe")
+                project_root
+                    .join(".sidecar-venv")
+                    .join("Scripts")
+                    .join("python.exe")
             } else {
-                project_root.join(".sidecar-venv").join("bin").join("python")
+                project_root
+                    .join(".sidecar-venv")
+                    .join("bin")
+                    .join("python")
             };
-            
+
             let script_path = project_root.join("sidecar").join("kokoro_server.py");
 
             // If not found at current_dir, try a few levels up (sometimes dev runners change CWD)
             if !python_path.exists() {
-               if let Ok(exe_path) = std::env::current_exe() {
-                   let mut p = exe_path.clone();
-                   // Try to find the root by looking for .sidecar-venv
-                   for _ in 0..10 {
-                       if p.join(".sidecar-venv").exists() {
-                           project_root = p;
-                           python_path = if cfg!(target_os = "windows") {
-                               project_root.join(".sidecar-venv").join("Scripts").join("python.exe")
-                           } else {
-                               project_root.join(".sidecar-venv").join("bin").join("python")
-                           };
-                           break;
-                       }
-                       if let Some(parent) = p.parent() {
-                           p = parent.to_path_buf();
-                       } else {
-                           break;
-                       }
-                   }
-               }
+                if let Ok(exe_path) = std::env::current_exe() {
+                    let mut p = exe_path.clone();
+                    // Try to find the root by looking for .sidecar-venv
+                    for _ in 0..10 {
+                        if p.join(".sidecar-venv").exists() {
+                            project_root = p;
+                            python_path = if cfg!(target_os = "windows") {
+                                project_root
+                                    .join(".sidecar-venv")
+                                    .join("Scripts")
+                                    .join("python.exe")
+                            } else {
+                                project_root
+                                    .join(".sidecar-venv")
+                                    .join("bin")
+                                    .join("python")
+                            };
+                            break;
+                        }
+                        if let Some(parent) = p.parent() {
+                            p = parent.to_path_buf();
+                        } else {
+                            break;
+                        }
+                    }
+                }
             }
 
             println!("[Kokoro] Final Project Root: {:?}", project_root);
             println!("[Kokoro] Venv Python: {:?}", python_path);
 
             if !python_path.exists() {
-                return Err(format!("Python venv not found. Tried looking in {:?} and path {:?}", project_root, python_path));
+                return Err(format!(
+                    "Python venv not found. Tried looking in {:?} and path {:?}",
+                    project_root, python_path
+                ));
             }
 
-            let cmd = app.shell().command(python_path.to_string_lossy().to_string())
+            let cmd = app
+                .shell()
+                .command(python_path.to_string_lossy().to_string())
                 .args([script_path.to_string_lossy().to_string()]);
-            
-            cmd.spawn().map_err(|e| format!("Failed to spawn python source: {e}"))?
+
+            cmd.spawn()
+                .map_err(|e| format!("Failed to spawn python source: {e}"))?
         } else {
             println!("[Kokoro] RELEASE MODE: Spawning bundled sidecar binary...");
-            let sidecar = app.shell()
+            let sidecar = app
+                .shell()
                 .sidecar("kokoro")
                 .map_err(|e| format!("Failed to create sidecar command: {e}"))?;
 
-            sidecar.spawn().map_err(|e| format!("Failed to spawn sidecar binary: {e}"))?
+            sidecar
+                .spawn()
+                .map_err(|e| format!("Failed to spawn sidecar binary: {e}"))?
         };
 
         let log_file_arc2 = Arc::clone(&log_file_arc);
@@ -183,8 +227,29 @@ impl SidecarManager {
                                 let _ = writeln!(f, "{}", line_str.trim_end());
                             }
                         }
-                        // Emit events based on sidecar logs for the frontend
-                        if line_str.contains("Chunk 0") {
+                        // Structured lifecycle events are forwarded verbatim. Legacy log
+                        // parsing remains temporarily for compatibility with old sidecars.
+                        if let Some(tts_event) = parse_tts_event(&line_str) {
+                            if tts_event.event == "error" {
+                                let error_msg = tts_event
+                                    .data
+                                    .get("message")
+                                    .and_then(|value| value.as_str())
+                                    .unwrap_or("Unknown TTS error");
+                                if let Ok(mut f) = std::fs::OpenOptions::new()
+                                    .create(true)
+                                    .append(true)
+                                    .open(&log_path_for_errors)
+                                {
+                                    let _ = writeln!(
+                                        f,
+                                        "[TTS ERROR request={}] {}",
+                                        tts_event.request_id, error_msg,
+                                    );
+                                }
+                            }
+                            let _ = handle_for_stdout.emit("tts-event", tts_event);
+                        } else if line_str.contains("Chunk 0") {
                             let _ = handle_for_stdout.emit("tts-speaking", ());
                         } else if line_str.contains("[STATUS] FINISHED") {
                             let _ = handle_for_stdout.emit("tts-finished", ());
@@ -237,7 +302,7 @@ impl SidecarManager {
         });
 
         self.child = Some(child);
-        
+
         // ─── Health Check Polling ───
         let handle_for_health = app.clone();
         let status_arc = Arc::clone(&self.status);
@@ -246,12 +311,12 @@ impl SidecarManager {
                 .timeout(Duration::from_millis(500))
                 .build()
                 .unwrap_or_default();
-            
+
             let mut attempts = 0;
             // PyInstaller one-file bundles can take close to a minute to
             // extract and import Torch on first launch, especially on macOS.
             let max_attempts = 180; // ~90 seconds when connections are refused quickly
-            
+
             while attempts < max_attempts {
                 match client.get("http://127.0.0.1:8790/health").send().await {
                     Ok(res) if res.status().is_success() => {
@@ -267,13 +332,16 @@ impl SidecarManager {
                     _ => {
                         attempts += 1;
                         if attempts % 10 == 0 {
-                            println!("[Kokoro] Waiting for sidecar health check... (attempt {})", attempts);
+                            println!(
+                                "[Kokoro] Waiting for sidecar health check... (attempt {})",
+                                attempts
+                            );
                         }
                         tokio::time::sleep(Duration::from_millis(500)).await;
                     }
                 }
             }
-            
+
             if attempts >= max_attempts {
                 eprintln!("[Kokoro] Sidecar health check timed out.");
                 {
@@ -291,7 +359,7 @@ impl SidecarManager {
     pub fn kill(&mut self) {
         if let Some(child) = self.child.take() {
             let pid = child.pid();
-            
+
             #[cfg(target_os = "windows")]
             {
                 // Force kill the process tree to ensure spawned multiprocessing workers die
@@ -315,7 +383,10 @@ impl SidecarManager {
                     *s = "disconnected".into();
                 }
                 Err(e) => {
-                    println!("[Kokoro] Sidecar killed or already dead (PID: {}). Error: {}", pid, e);
+                    println!(
+                        "[Kokoro] Sidecar killed or already dead (PID: {}). Error: {}",
+                        pid, e
+                    );
                     let mut s = self.status.lock().unwrap();
                     *s = "disconnected".into();
                 }
@@ -331,5 +402,33 @@ impl SidecarManager {
 impl Drop for SidecarManager {
     fn drop(&mut self) {
         self.kill();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_tts_event, TTS_EVENT_PREFIX};
+
+    #[test]
+    fn parses_structured_tts_event() {
+        let line = concat!(
+            "[TTS_EVENT] ",
+            r#"{"schemaVersion":1,"requestId":"request-123","event":"chunk_ready","timestampMs":42,"data":{"chunkIndex":0}}"#,
+        );
+
+        let event = parse_tts_event(line).expect("event should parse");
+
+        assert_eq!(event.schema_version, 1);
+        assert_eq!(event.request_id, "request-123");
+        assert_eq!(event.event, "chunk_ready");
+        assert_eq!(event.timestamp_ms, 42);
+        assert_eq!(event.data["chunkIndex"], 0);
+    }
+
+    #[test]
+    fn ignores_human_readable_and_malformed_logs() {
+        assert!(parse_tts_event("[Sidecar] Generated chunk 0").is_none());
+        assert!(parse_tts_event(TTS_EVENT_PREFIX).is_none());
+        assert!(parse_tts_event("[TTS_EVENT] {not-json}").is_none());
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -20,7 +20,7 @@
         "height": 140,
         "decorations": false,
         "transparent": true,
-        "shadow": false,
+        "shadow": true,
         "alwaysOnTop": true,
         "visible": false,
         "resizable": false,

--- a/src/components/FloatingWidget.tsx
+++ b/src/components/FloatingWidget.tsx
@@ -1,10 +1,28 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { load } from "@tauri-apps/plugin-store";
 import { listen } from "@tauri-apps/api/event";
-import { readText } from "@tauri-apps/plugin-clipboard-manager";
 import { error } from "@tauri-apps/plugin-log";
-import { cleanTextForTTS } from "../utils/textCleaner";
+import {
+  structuredClipboardText,
+  type ClipboardPayload,
+} from "../utils/clipboardStructure";
+import { planTextForTTS, type SpeechSegment } from "../utils/speechPlanner";
+import {
+  estimateFirstAudioMs,
+  estimatedGenerationProgress,
+  estimatedRemainingLabel,
+  recordFirstAudioSample,
+  type FirstAudioContext,
+  type FirstAudioSample,
+} from "../utils/firstAudioEstimator";
+import {
+  eventBelongsToRequest,
+  statusForTtsEvent,
+  type TtsLifecycleEvent,
+  type TtsStatus,
+} from "../utils/ttsEvents";
 
 // ─── Speed Notches ───────────────────────────────────────────────────────────
 // Range: 0.5x – 2.0x in 0.1 increments (16 notches).
@@ -15,6 +33,12 @@ const SPEED_NOTCHES = [
   1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
 ] as const;
 const DEFAULT_SPEED_INDEX = 5; // 1.0x
+const FIRST_AUDIO_HISTORY_KEY = "first-audio-history-v2";
+const DEFAULT_BACKEND_ID = "kokoro-pytorch-cpu";
+
+type ReaderSettingsUpdate = {
+  skipCodeBlocks?: boolean;
+};
 
 // ─── Icons ──────────────────────────────────────────────────────────────────
 const PlayIcon = () => (
@@ -47,43 +71,120 @@ const CopyIcon = () => (
   </svg>
 );
 
-type Status = "Idle" | "Generating" | "Speaking" | "Paused" | "TTS Error";
-
 export default function FloatingWidget() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [speedIndex, setSpeedIndex] = useState(DEFAULT_SPEED_INDEX);
-  const [status, setStatus] = useState<Status>("Idle");
+  const [status, setStatus] = useState<TtsStatus>("Idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [flashKey, setFlashKey] = useState(0); // full widget flash (on hotkey)
   const [subtleFlashKey, setSubtleFlashKey] = useState(0); // tiny dot pulse (on global copy)
+  const [generationElapsedMs, setGenerationElapsedMs] = useState(0);
+  const [firstAudioContext, setFirstAudioContext] = useState<FirstAudioContext | null>(null);
   const hasEnteredRef = useRef(false);
+  const speedIndexRef = useRef(DEFAULT_SPEED_INDEX);
   const storeRef = useRef<Awaited<ReturnType<typeof load>> | null>(null);
+  const activeRequestIdRef = useRef<string | null>(null);
+  const requestReceivedAtRef = useRef<number | null>(null);
+  const firstAudioContextRef = useRef<FirstAudioContext | null>(null);
+  const firstAudioHistoryRef = useRef<FirstAudioSample[]>([]);
+  const skipCodeBlocksRef = useRef(false);
 
   const speed = SPEED_NOTCHES[speedIndex];
-  const lastAnalyzedText = useRef<string>("");
+  const lastSpeechPlan = useRef<SpeechSegment[]>([]);
 
   // ── Dragging ──
   // ── Load persisted speed ──
   useEffect(() => {
     (async () => {
-      const store = await load("settings.json", { defaults: { "tts-speed-index": DEFAULT_SPEED_INDEX }, autoSave: true });
+      const store = await load("settings.json", {
+        defaults: {
+          "tts-speed-index": DEFAULT_SPEED_INDEX,
+          [FIRST_AUDIO_HISTORY_KEY]: [],
+        },
+        autoSave: true,
+      });
       storeRef.current = store;
       const saved = await store.get<number>("tts-speed-index");
+      const savedFirstAudioHistory = await store.get<FirstAudioSample[]>(FIRST_AUDIO_HISTORY_KEY);
+      const savedSkipCodeBlocks = await store.get<boolean>("skip-code-blocks");
+      if (typeof savedSkipCodeBlocks === "boolean") {
+        skipCodeBlocksRef.current = savedSkipCodeBlocks;
+      }
+      if (Array.isArray(savedFirstAudioHistory)) {
+        firstAudioHistoryRef.current = savedFirstAudioHistory.filter(
+          (sample) => (
+            typeof sample === "object"
+            && sample !== null
+            && typeof sample.backend === "string"
+            && typeof sample.voice === "string"
+            && typeof sample.firstSegmentChars === "number"
+            && typeof sample.durationMs === "number"
+          ),
+        );
+      }
       if (typeof saved === 'number' && saved >= 0 && saved < SPEED_NOTCHES.length) {
+        speedIndexRef.current = saved;
         setSpeedIndex(saved);
       } else {
+        speedIndexRef.current = DEFAULT_SPEED_INDEX;
         setSpeedIndex(DEFAULT_SPEED_INDEX);
       }
     })();
   }, []);
 
+  useEffect(() => {
+    const unlisten = listen<ReaderSettingsUpdate>("settings-updated", (event) => {
+      if (typeof event.payload.skipCodeBlocks === "boolean") {
+        skipCodeBlocksRef.current = event.payload.skipCodeBlocks;
+      }
+    });
+    return () => { unlisten.then(fn => fn()); };
+  }, []);
+
   // ── Listen for Sidecar Events ──
   useEffect(() => {
-    const unlistenSpeaking = listen("tts-speaking", () => setStatus("Speaking"));
-    const unlistenFinished = listen("tts-finished", () => {
-      setStatus("Idle");
-      setIsPlaying(false);
+    const unlistenLifecycle = listen<TtsLifecycleEvent>("tts-event", (event) => {
+      const lifecycle = event.payload;
+      if (!eventBelongsToRequest(lifecycle, activeRequestIdRef.current)) return;
+
+      if (lifecycle.event === "request_received") {
+        requestReceivedAtRef.current = lifecycle.timestampMs;
+      } else if (
+        lifecycle.event === "playback_started"
+        && requestReceivedAtRef.current !== null
+        && firstAudioContextRef.current !== null
+      ) {
+        const durationMs = lifecycle.timestampMs - requestReceivedAtRef.current;
+        const nextHistory = recordFirstAudioSample(
+          firstAudioHistoryRef.current,
+          durationMs,
+          firstAudioContextRef.current,
+        );
+        firstAudioHistoryRef.current = nextHistory;
+        requestReceivedAtRef.current = null;
+        void storeRef.current?.set(FIRST_AUDIO_HISTORY_KEY, nextHistory);
+      }
+
+      const nextStatus = statusForTtsEvent(lifecycle);
+      if (nextStatus) setStatus(nextStatus);
+
+      if (nextStatus === "Idle") {
+        activeRequestIdRef.current = null;
+        requestReceivedAtRef.current = null;
+        setIsPlaying(false);
+      } else if (nextStatus === "TTS Error") {
+        const msg = typeof lifecycle.data.message === "string"
+          ? lifecycle.data.message
+          : "Unknown error";
+        setErrorMessage(msg);
+        activeRequestIdRef.current = null;
+        requestReceivedAtRef.current = null;
+        setIsPlaying(false);
+      }
     });
+
+    // Process-level failures do not belong to a TTS request and retain their
+    // legacy channel until the sidecar manager has its own structured protocol.
     const unlistenError = listen<string>("tts-error", (event) => {
       const msg = event.payload || "Unknown error";
       console.error("[Kokoro UI] Sidecar error:", msg);
@@ -93,8 +194,7 @@ export default function FloatingWidget() {
     });
 
     return () => {
-      unlistenSpeaking.then(fn => fn());
-      unlistenFinished.then(fn => fn());
+      unlistenLifecycle.then(fn => fn());
       unlistenError.then(fn => fn());
     };
   }, []);
@@ -104,9 +204,32 @@ export default function FloatingWidget() {
     storeRef.current?.set("tts-speed-index", speedIndex);
   }, [speedIndex]);
 
+  useEffect(() => {
+    if (status !== "Generating") return;
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      setGenerationElapsedMs(Date.now() - startedAt);
+    }, 100);
+    return () => window.clearInterval(timer);
+  }, [status]);
+
   // ── TTS Logic ──
-  const runTTS = async (text: string) => {
+  const runTTS = async (speechPlan: SpeechSegment[]) => {
     try {
+      const synthesisSegments = speechPlan
+        .filter((segment) => segment.spokenText)
+        .map(({ id, kind, spokenText, pauseAfterMs }) => ({
+          id,
+          kind,
+          spokenText,
+          pauseAfterMs,
+        }));
+      if (synthesisSegments.length === 0) return;
+
+      const requestId = crypto.randomUUID();
+      activeRequestIdRef.current = requestId;
+      requestReceivedAtRef.current = null;
+      setGenerationElapsedMs(0);
       setStatus("Generating");
       setIsPlaying(true);
       setErrorMessage(""); // clear any previous error
@@ -114,14 +237,23 @@ export default function FloatingWidget() {
       const store = storeRef.current || await load("settings.json", { defaults: {}, autoSave: true });
       const voice = (await store.get<string>("voice")) || "am_fenrir";
       const volume = (await store.get<number>("volume")) ?? 1.0;
+      const estimatorContext = {
+        backend: DEFAULT_BACKEND_ID,
+        voice,
+        firstSegmentChars: synthesisSegments[0].spokenText.length,
+      } satisfies FirstAudioContext;
+      firstAudioContextRef.current = estimatorContext;
+      setFirstAudioContext(estimatorContext);
 
       await invoke("send_to_tts", { 
-        text, 
+        text: synthesisSegments.map((segment) => segment.spokenText).join("\n"),
         speed: speed, 
         voice: voice,
-        volume: volume 
+        volume: volume,
+        requestId,
+        segments: synthesisSegments,
       });
-      // status remains "Generating" until "tts-speaking" event arrives
+      // Status remains "Generating" until the first audible buffer is reported.
     } catch (err) {
       const msg = String(err);
       error(`[Kokoro UI] Invoke error: ${msg}`);
@@ -135,17 +267,20 @@ export default function FloatingWidget() {
   useEffect(() => {
     const unlisten = listen("shortcut-triggered", async () => {
       try {
-        const clipboardText = await readText();
+        const clipboardPayload = await invoke<ClipboardPayload>("read_clipboard_payload");
+        const clipboardText = structuredClipboardText(clipboardPayload);
         if (clipboardText && clipboardText.trim()) {
-          const cleaned = cleanTextForTTS(clipboardText);
-          lastAnalyzedText.current = cleaned;
+          const speechPlan = planTextForTTS(clipboardText, {
+            skipCodeBlocks: skipCodeBlocksRef.current,
+          });
+          lastSpeechPlan.current = speechPlan;
 
           // Fixes #11: flash the widget to confirm clipboard text received
           setFlashKey((k) => k + 1);
           
           // Smart Positioning: only move to cursor if not already visible
           await invoke("ensure_reader_visible");
-          await runTTS(cleaned);
+          await runTTS(speechPlan);
         }
       } catch (err) {
         error(`[Kokoro UI] Shortcut handler error: ${err}`);
@@ -165,11 +300,21 @@ export default function FloatingWidget() {
 
   // ── Speed cycling ──
   const cycleSpeed = useCallback((direction: 1 | -1) => {
-    setSpeedIndex((prev) => {
-      const next = (prev + direction + SPEED_NOTCHES.length) % SPEED_NOTCHES.length;
-      return next;
-    });
-  }, []);
+    const next = (
+      speedIndexRef.current + direction + SPEED_NOTCHES.length
+    ) % SPEED_NOTCHES.length;
+    speedIndexRef.current = next;
+    setSpeedIndex(next);
+    if (
+      activeRequestIdRef.current
+      && (status === "Generating" || status === "Speaking" || status === "Paused")
+    ) {
+      void invoke("set_tts_speed", {
+        requestId: activeRequestIdRef.current,
+        speed: SPEED_NOTCHES[next],
+      }).catch((err) => error(String(err)));
+    }
+  }, [status]);
 
   // ── Scroll-wheel handler ──
   const handleWheel = useCallback(
@@ -184,32 +329,48 @@ export default function FloatingWidget() {
   const handlePlayPause = useCallback(async () => {
     if (status === "Speaking") {
       // If speaking, pause it (Issue #5)
-      await invoke("pause_tts").catch((err) => error(String(err)));
-      setStatus("Paused");
+      await invoke("pause_tts", { requestId: activeRequestIdRef.current ?? "" })
+        .catch((err) => error(String(err)));
     } else if (status === "Paused") {
       // If paused, resume it
-      await invoke("resume_tts").catch((err) => error(String(err)));
-      setStatus("Speaking");
+      await invoke("resume_tts", { requestId: activeRequestIdRef.current ?? "" })
+        .catch((err) => error(String(err)));
     } else if (status === "Idle" || status === "TTS Error") {
       // If idle, start a fresh run
-      if (lastAnalyzedText.current) {
-        await runTTS(lastAnalyzedText.current);
+      if (lastSpeechPlan.current.length > 0) {
+        await runTTS(lastSpeechPlan.current);
       }
     }
   }, [isPlaying, status, speed]);
 
   // ── Stop ──
   const handleStop = useCallback(async () => {
-    await invoke("stop_tts").catch((err) => error(String(err)));
+    const requestId = activeRequestIdRef.current;
+    if (requestId) {
+      await invoke("stop_tts", { requestId }).catch((err) => error(String(err)));
+    }
     setIsPlaying(false);
     setStatus("Idle");
   }, []);
 
   // ── Close ──
   const handleClose = useCallback(async () => {
-    await handleStop();
-    await invoke("hide_reader_window").catch((err) => error(String(err)));
-  }, [handleStop]);
+    const requestId = activeRequestIdRef.current;
+    activeRequestIdRef.current = null;
+    setIsPlaying(false);
+    setStatus("Idle");
+
+    // Hiding the widget must never wait for inference, playback, or a sidecar
+    // control request. Fall back to the Rust command if the local window API
+    // is unavailable during teardown.
+    await getCurrentWebviewWindow().hide().catch(async () => {
+      await invoke("hide_reader_window");
+    }).catch((err) => error(String(err)));
+
+    if (requestId) {
+      void invoke("stop_tts", { requestId }).catch((err) => error(String(err)));
+    }
+  }, []);
 
   const statusColor = 
     status === 'Speaking' ? 'text-[#8AB4F8]' : 
@@ -217,6 +378,19 @@ export default function FloatingWidget() {
     status === 'Paused' ? 'text-[#8AB4F8]/60' : 
     status === 'TTS Error' ? 'text-red-400' : 
     'text-white/20';
+
+  const firstAudioEstimateMs = estimateFirstAudioMs(
+    firstAudioHistoryRef.current,
+    firstAudioContext,
+  );
+  const generationProgress = estimatedGenerationProgress(
+    generationElapsedMs,
+    firstAudioEstimateMs,
+  );
+  const generationRemaining = estimatedRemainingLabel(
+    generationElapsedMs,
+    firstAudioEstimateMs,
+  );
   
   // Only play the entrance pop once
   useEffect(() => {
@@ -272,7 +446,7 @@ export default function FloatingWidget() {
         </button>
 
         {/* Status Hub */}
-        <div className="flex flex-col px-1 min-w-[64px] pointer-events-none" data-tauri-drag-region>
+        <div className="flex flex-col px-1 min-w-[72px] pointer-events-none" data-tauri-drag-region>
           <span
             className={`text-[8px] font-black uppercase tracking-[0.15em] leading-none transition-smooth ${statusColor} ${status === 'TTS Error' && errorMessage ? 'pointer-events-auto cursor-help' : ''}`}
             title={status === 'TTS Error' && errorMessage ? errorMessage : undefined}
@@ -280,6 +454,11 @@ export default function FloatingWidget() {
           >
             {status}
           </span>
+          {status === "Generating" && (
+            <span className="mt-1 text-[8px] leading-none text-white/35 tabular-nums">
+              {generationRemaining ?? "estimating"}
+            </span>
+          )}
         </div>
 
         {/* Speed Bubble */}
@@ -301,8 +480,9 @@ export default function FloatingWidget() {
 
         {/* Close */}
         <button
+          type="button"
           onClick={handleClose}
-          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
           title="Close"
           className="
             w-7 h-7 rounded-full flex items-center justify-center shrink-0
@@ -313,6 +493,19 @@ export default function FloatingWidget() {
         >
           <CloseIcon />
         </button>
+
+        {status === "Generating" && (
+          <div className="generation-progress-track" aria-hidden="true">
+            {generationProgress === null ? (
+              <div className="generation-progress-indeterminate" />
+            ) : (
+              <div
+                className="generation-progress-value"
+                style={{ transform: `scaleX(${generationProgress})` }}
+              />
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -32,6 +32,7 @@ export default function SettingsWindow() {
   const [recording, setRecording] = useState(false);
   const [saved, setSaved] = useState(false);
   const [volume, setVolume] = useState(1.0);
+  const [skipCodeBlocks, setSkipCodeBlocks] = useState(false);
   
   const [devices, setDevices] = useState<{id: number, name: string}[]>([]);
   const [currentDevice, setCurrentDevice] = useState<number>(0);
@@ -67,6 +68,8 @@ export default function SettingsWindow() {
       if (typeof vol === 'number') {
         setVolume(vol);
       }
+      const skipCode = await store.get<boolean>("skip-code-blocks");
+      if (typeof skipCode === "boolean") setSkipCodeBlocks(skipCode);
     })();
   }, []);
 
@@ -77,7 +80,9 @@ export default function SettingsWindow() {
     await store.set("shortcut", shortcut);
     await store.set("shortcut-enabled", shortcutEnabled);
     await store.set("volume", volume);
+    await store.set("skip-code-blocks", skipCodeBlocks);
     await store.save();
+    await emit("settings-updated", { skipCodeBlocks });
 
     // Re-register the shortcut
     try {
@@ -102,7 +107,7 @@ export default function SettingsWindow() {
 
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
-  }, [voice, shortcut, shortcutEnabled, volume]);
+  }, [voice, shortcut, shortcutEnabled, volume, skipCodeBlocks]);
 
   // ── Key recorder ──
   const handleKeyRecord = useCallback((e: React.KeyboardEvent) => {
@@ -221,6 +226,28 @@ export default function SettingsWindow() {
             onChange={(e) => setVolume(parseFloat(e.target.value))}
             className="w-full h-1.5 rounded-lg appearance-none cursor-pointer bg-[#2D2D2D] accent-[#8AB4F8] hover:accent-[#AECBFA] transition-smooth"
           />
+        </div>
+
+        {/* Code behavior */}
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-sm text-white/70">Skip Code Blocks</div>
+            <p className="mt-1 text-[11px] leading-relaxed text-white/35">
+              Always announces the block. When enabled, says “Code block skipped” instead of reading it.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={skipCodeBlocks}
+            aria-label="Skip code blocks"
+            onClick={() => setSkipCodeBlocks(!skipCodeBlocks)}
+            className={`mt-0.5 w-10 h-5 shrink-0 rounded-full transition-smooth relative ${skipCodeBlocks ? "bg-[#8AB4F8]" : "bg-white/10"}`}
+          >
+            <span
+              className={`absolute top-0.5 w-4 h-4 rounded-full shadow-sm transition-smooth ${skipCodeBlocks ? "left-5.5 bg-[#202124]" : "left-0.5 bg-white/40"}`}
+            />
+          </button>
         </div>
 
         {/* Global Shortcut */}

--- a/src/index.css
+++ b/src/index.css
@@ -127,6 +127,41 @@
     position: relative;
   }
 
+  .generation-progress-track {
+    position: absolute;
+    left: 14px;
+    right: 14px;
+    bottom: 0;
+    height: 2px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    pointer-events: none;
+  }
+
+  .generation-progress-value,
+  .generation-progress-indeterminate {
+    width: 100%;
+    height: 100%;
+    transform-origin: left center;
+    border-radius: inherit;
+    background: rgba(250, 204, 21, 0.7);
+  }
+
+  .generation-progress-value {
+    transition: transform 100ms linear;
+  }
+
+  .generation-progress-indeterminate {
+    width: 38%;
+    animation: generation-progress-scan 1.1s ease-in-out infinite;
+  }
+
+  @keyframes generation-progress-scan {
+    from { transform: translateX(-110%); }
+    to { transform: translateX(365%); }
+  }
+
   .animate-text-update {
     animation: text-update 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
   }

--- a/src/utils/clipboardStructure.test.ts
+++ b/src/utils/clipboardStructure.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { structuredClipboardText } from "./clipboardStructure";
+import { planTextForTTS } from "./speechPlanner";
+
+describe("structured clipboard recovery", () => {
+  it("recovers headings and paragraph boundaries from matching HTML", () => {
+    const result = structuredClipboardText({
+      text: "Why this matters\nThe listener needs a moment.\nThen the next thought begins.",
+      html: "<h2>Why this matters</h2><p>The listener needs a moment.</p><p>Then the next thought begins.</p>",
+    });
+
+    expect(result).toBe([
+      "## Why this matters",
+      "",
+      "The listener needs a moment.",
+      "",
+      "Then the next thought begins.",
+    ].join("\n"));
+    expect(planTextForTTS(result).map(({ kind, pauseAfterMs }) => ({
+      kind,
+      pauseAfterMs,
+    }))).toEqual([
+      { kind: "heading", pauseAfterMs: 550 },
+      { kind: "paragraph", pauseAfterMs: 420 },
+      { kind: "paragraph", pauseAfterMs: 420 },
+    ]);
+  });
+
+  it("turns explicit HTML line breaks into pause-worthy boundaries", () => {
+    expect(structuredClipboardText({
+      text: "First thought\nSecond thought",
+      html: "First thought<br>Second thought",
+    })).toBe("First thought\n\nSecond thought");
+  });
+
+  it("falls back to plain text when rich and plain clipboard content disagree", () => {
+    expect(structuredClipboardText({
+      text: "The text the user selected.",
+      html: "<h1>Unrelated clipboard content</h1>",
+    })).toBe("The text the user selected.");
+  });
+
+  it("ignores executable and styling elements", () => {
+    expect(structuredClipboardText({
+      text: "Safe text",
+      html: "<style>hidden</style><script>bad()</script><p>Safe text</p>",
+    })).toBe("Safe text");
+  });
+});

--- a/src/utils/clipboardStructure.ts
+++ b/src/utils/clipboardStructure.ts
@@ -1,0 +1,89 @@
+export type ClipboardPayload = {
+  text?: string | null;
+  html?: string | null;
+};
+
+const IGNORED_HTML_TAGS = new Set([
+  "script",
+  "style",
+  "noscript",
+  "svg",
+  "canvas",
+  "template",
+]);
+
+function renderChildren(element: Element): string {
+  return Array.from(element.childNodes).map(renderNode).join("");
+}
+
+function renderNode(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) return node.nodeValue ?? "";
+  if (node.nodeType !== Node.ELEMENT_NODE) return "";
+
+  const element = node as Element;
+  const tag = element.tagName.toLowerCase();
+  if (IGNORED_HTML_TAGS.has(tag)) return "";
+
+  const content = renderChildren(element);
+  if (/^h[1-6]$/.test(tag)) {
+    return `\n\n${"#".repeat(Number(tag[1]))} ${content}\n\n`;
+  }
+  if (tag === "p" || tag === "section" || tag === "article") {
+    return `\n\n${content}\n\n`;
+  }
+  if (tag === "blockquote") return `\n\n> ${element.textContent ?? ""}\n\n`;
+  if (tag === "br") return "\n\n";
+  if (tag === "div") return `\n${content}\n`;
+  if (tag === "li") {
+    const parent = element.parentElement;
+    const ordered = parent?.tagName.toLowerCase() === "ol";
+    const siblings = parent
+      ? Array.from(parent.children).filter((child) => child.tagName.toLowerCase() === "li")
+      : [];
+    const marker = ordered ? `${siblings.indexOf(element) + 1}.` : "-";
+    return `\n${marker} ${content}\n`;
+  }
+  if (tag === "ul" || tag === "ol") return `\n${content}\n`;
+  if (tag === "pre") return `\n\n\`\`\`\n${element.textContent ?? ""}\n\`\`\`\n\n`;
+  if (tag === "tr") return `\n${content}\n`;
+  if (tag === "td" || tag === "th") return `${content} `;
+  return content;
+}
+
+function normalizeStructuredText(value: string): string {
+  return value
+    .replace(/\u00a0/g, " ")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function canonicalWords(value: string): string {
+  return value
+    .normalize("NFC")
+    .replace(/^\s*```[^\n]*$/gm, " ")
+    .replace(/^\s*(?:#{1,6}\s+|[-+*•]\s+|\d+[.)]\s+|>\s*)/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Prefer semantic HTML boundaries only when its visible words agree with the
+ * plain-text clipboard representation. This keeps rich clipboard recovery a
+ * structural hint, never a content-rewriting step.
+ */
+export function structuredClipboardText(payload: ClipboardPayload): string {
+  const plainText = normalizeStructuredText(payload.text ?? "");
+  if (!payload.html?.trim() || typeof DOMParser === "undefined") return plainText;
+
+  const document = new DOMParser().parseFromString(payload.html, "text/html");
+  const structured = normalizeStructuredText(renderChildren(document.body));
+  if (!structured) return plainText;
+  if (!plainText) return structured;
+  if (canonicalWords(structured) !== canonicalWords(plainText)) return plainText;
+
+  const carriesStructure = /\n|^\s*(?:#{1,6}|[-+*]|\d+[.)]|>)/m.test(structured);
+  return carriesStructure ? structured : plainText;
+}

--- a/src/utils/firstAudioEstimator.test.ts
+++ b/src/utils/firstAudioEstimator.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateFirstAudioMs,
+  estimatedGenerationProgress,
+  estimatedRemainingLabel,
+  recordFirstAudioSample,
+  type FirstAudioContext,
+  type FirstAudioSample,
+} from "./firstAudioEstimator";
+
+const context: FirstAudioContext = {
+  backend: "kokoro-pytorch-cpu",
+  voice: "am_fenrir",
+  firstSegmentChars: 30,
+};
+
+function sample(durationMs: number, overrides = {}): FirstAudioSample {
+  return { ...context, durationMs, ...overrides };
+}
+
+describe("first audio estimator", () => {
+  it("keeps only recent valid contextual samples", () => {
+    let history: FirstAudioSample[] = [];
+    history = recordFirstAudioSample(history, 800, context, 3);
+    history = recordFirstAudioSample(history, Number.NaN, context, 3);
+    history = recordFirstAudioSample(history, 900, context, 3);
+    history = recordFirstAudioSample(history, 1000, context, 3);
+    history = recordFirstAudioSample(history, 1100, context, 3);
+    expect(history.map(({ durationMs }) => durationMs)).toEqual([900, 1000, 1100]);
+  });
+
+  it("uses a robust median after three comparable observations", () => {
+    expect(estimateFirstAudioMs([sample(800), sample(900)], context)).toBeNull();
+    expect(estimateFirstAudioMs([sample(800), sample(900), sample(12_000)], context)).toBe(900);
+    expect(estimateFirstAudioMs(
+      [sample(700), sample(800), sample(900), sample(1000)],
+      context,
+    )).toBe(850);
+  });
+
+  it("does not mix voices, backends, or segment-size buckets", () => {
+    const history = [
+      sample(700),
+      sample(800),
+      sample(900),
+      sample(5000, { voice: "af_heart" }),
+      sample(6000, { backend: "experimental-mps" }),
+      sample(7000, { firstSegmentChars: 120 }),
+    ];
+    expect(estimateFirstAudioMs(history, context)).toBe(800);
+    expect(estimateFirstAudioMs(history, { ...context, voice: "af_heart" })).toBeNull();
+    expect(estimateFirstAudioMs(history, { ...context, firstSegmentChars: 120 })).toBeNull();
+  });
+
+  it("never predicts completion before the playback event", () => {
+    expect(estimatedGenerationProgress(500, null)).toBeNull();
+    expect(estimatedGenerationProgress(500, 1000)).toBe(0.45);
+    expect(estimatedGenerationProgress(5000, 1000)).toBe(0.9);
+  });
+
+  it("shows a coarse remaining-time label", () => {
+    expect(estimatedRemainingLabel(250, 1000)).toBe("~1.0s");
+    expect(estimatedRemainingLabel(700, 1000)).toBe("~0.5s");
+    expect(estimatedRemainingLabel(1200, 1000)).toBe("almost ready");
+    expect(estimatedRemainingLabel(100, null)).toBeNull();
+  });
+});

--- a/src/utils/firstAudioEstimator.ts
+++ b/src/utils/firstAudioEstimator.ts
@@ -1,0 +1,96 @@
+export const MAX_FIRST_AUDIO_SAMPLES = 20;
+export const MIN_SAMPLES_FOR_ESTIMATE = 3;
+
+export type FirstAudioContext = {
+  backend: string;
+  voice: string;
+  firstSegmentChars: number;
+};
+
+export type FirstAudioSample = FirstAudioContext & {
+  durationMs: number;
+};
+
+type SegmentSizeBucket = "short" | "medium" | "long";
+
+function segmentSizeBucket(characterCount: number): SegmentSizeBucket {
+  if (characterCount <= 40) return "short";
+  if (characterCount <= 90) return "medium";
+  return "long";
+}
+
+function isComparable(sample: FirstAudioSample, context: FirstAudioContext): boolean {
+  return sample.backend === context.backend
+    && sample.voice === context.voice
+    && segmentSizeBucket(sample.firstSegmentChars) === segmentSizeBucket(context.firstSegmentChars);
+}
+
+export function recordFirstAudioSample(
+  history: readonly FirstAudioSample[],
+  durationMs: number,
+  context: FirstAudioContext,
+  maxSamples = MAX_FIRST_AUDIO_SAMPLES,
+): FirstAudioSample[] {
+  if (
+    !Number.isFinite(durationMs)
+    || durationMs <= 0
+    || maxSamples <= 0
+    || !context.backend
+    || !context.voice
+    || !Number.isFinite(context.firstSegmentChars)
+    || context.firstSegmentChars <= 0
+  ) {
+    return [...history].slice(-Math.max(0, maxSamples));
+  }
+
+  // Ignore extreme process stalls. They are not useful predictions for a normal
+  // request and would make the small status indicator look broken for weeks.
+  const sample: FirstAudioSample = {
+    ...context,
+    firstSegmentChars: Math.round(context.firstSegmentChars),
+    durationMs: Math.min(Math.round(durationMs), 30_000),
+  };
+  return [...history, sample].slice(-maxSamples);
+}
+
+export function estimateFirstAudioMs(
+  history: readonly FirstAudioSample[],
+  context: FirstAudioContext | null,
+): number | null {
+  if (context === null) return null;
+  const samples = history
+    .filter((sample) => isComparable(sample, context))
+    .map((sample) => sample.durationMs)
+    .filter((durationMs) => Number.isFinite(durationMs) && durationMs > 0)
+    .sort((a, b) => a - b);
+  if (samples.length < MIN_SAMPLES_FOR_ESTIMATE) return null;
+
+  const middle = Math.floor(samples.length / 2);
+  const median = samples.length % 2 === 0
+    ? (samples[middle - 1] + samples[middle]) / 2
+    : samples[middle];
+  return Math.round(median);
+}
+
+export function estimatedGenerationProgress(
+  elapsedMs: number,
+  estimateMs: number | null,
+): number | null {
+  if (estimateMs === null || estimateMs <= 0) return null;
+  const safeElapsed = Math.max(0, elapsedMs);
+  // A time-based indicator must never claim completion before audio actually
+  // starts. It fills linearly to 90%, then waits truthfully for the real event.
+  return Math.min(0.9, safeElapsed / estimateMs * 0.9);
+}
+
+export function estimatedRemainingLabel(
+  elapsedMs: number,
+  estimateMs: number | null,
+): string | null {
+  if (estimateMs === null || estimateMs <= 0) return null;
+  const remainingMs = estimateMs - Math.max(0, elapsedMs);
+  if (remainingMs <= 0) return "almost ready";
+  // Half-second steps avoid implying precision the rolling median cannot offer.
+  const roundedSeconds = Math.max(0.5, Math.ceil(remainingMs / 500) * 0.5);
+  return `~${roundedSeconds.toFixed(1)}s`;
+}

--- a/src/utils/readerQualityCorpus.test.ts
+++ b/src/utils/readerQualityCorpus.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import corpus from "../../tests/fixtures/reader_quality_v1.json";
+import { MAX_SPEECH_SEGMENT_CHARS, planTextForTTS } from "./speechPlanner";
+
+describe("reader quality corpus", () => {
+  it("is versioned and has unique, non-empty cases", () => {
+    expect(corpus.schemaVersion).toBe(1);
+    expect(corpus.cases.length).toBeGreaterThanOrEqual(20);
+
+    const ids = corpus.cases.map((testCase) => testCase.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const testCase of corpus.cases) {
+      expect(testCase.input.trim()).not.toBe("");
+      expect(testCase.concerns.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers every v0.7 speech-planning risk category", () => {
+    const categories = new Set(corpus.cases.map((testCase) => testCase.category));
+    for (const required of [
+      "structure",
+      "chat",
+      "acronyms",
+      "numbers",
+      "technical",
+      "code",
+      "punctuation",
+      "long-form",
+      "privacy",
+    ]) {
+      expect(categories.has(required)).toBe(true);
+    }
+  });
+
+  it("contains critical fixtures for the reported product problems", () => {
+    const criticalConcerns = new Set(
+      corpus.cases
+        .filter((testCase) => testCase.priority === "critical")
+        .flatMap((testCase) => testCase.concerns),
+    );
+
+    for (const required of [
+      "paragraph-boundary",
+      "plain-text-heading-inference",
+      "list-boundary",
+      "shorthand",
+      "currency",
+      "code-policy",
+      "thought-digestion",
+      "first-audio-latency",
+      "release-log-redaction",
+    ]) {
+      expect(criticalConcerns.has(required)).toBe(true);
+    }
+  });
+
+  it("plans every fixture into bounded, source-mapped inference segments", () => {
+    for (const testCase of corpus.cases) {
+      const segments = planTextForTTS(testCase.input);
+      expect(segments.length, testCase.id).toBeGreaterThan(0);
+      expect(new Set(segments.map((segment) => segment.id)).size, testCase.id)
+        .toBe(segments.length);
+
+      for (const segment of segments) {
+        expect(
+          testCase.input.slice(segment.sourceStart, segment.sourceEnd),
+          `${testCase.id}/${segment.id}`,
+        ).toBe(segment.sourceText);
+        if (segment.spokenText) {
+          expect(segment.spokenText.length, `${testCase.id}/${segment.id}`)
+            .toBeLessThanOrEqual(MAX_SPEECH_SEGMENT_CHARS);
+        }
+      }
+    }
+  });
+
+  it("locks approved spoken forms into regression fixtures", () => {
+    for (const testCase of corpus.cases) {
+      if (!("expectedSpokenSegments" in testCase)) continue;
+      const actual = planTextForTTS(testCase.input)
+        .filter((segment) => segment.spokenText)
+        .map((segment) => segment.spokenText);
+      expect(actual, testCase.id).toEqual(testCase.expectedSpokenSegments);
+    }
+  });
+});

--- a/src/utils/speechPlanner.test.ts
+++ b/src/utils/speechPlanner.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_SPEECH_SEGMENT_CHARS,
+  normalizeCodeForSpeech,
+  planTextForTTS,
+} from "./speechPlanner";
+
+describe("speech planner", () => {
+  it("preserves paragraph boundaries and source offsets", () => {
+    const input = "The first thought ends here.\n\nThe second thought starts later.";
+
+    const segments = planTextForTTS(input);
+
+    expect(segments.map((segment) => segment.spokenText)).toEqual([
+      "The first thought ends here.",
+      "The second thought starts later.",
+    ]);
+    expect(segments.map((segment) => segment.kind)).toEqual(["paragraph", "paragraph"]);
+    expect(segments.map((segment) => segment.pauseAfterMs)).toEqual([420, 420]);
+    for (const segment of segments) {
+      expect(input.slice(segment.sourceStart, segment.sourceEnd)).toBe(segment.sourceText);
+    }
+  });
+
+  it("turns headings, list items, and quotes into semantic segments", () => {
+    const input = [
+      "## Priorities",
+      "- exact pause",
+      "2. faster audio",
+      "> Preserve the listener's context.",
+    ].join("\n");
+
+    const segments = planTextForTTS(input);
+
+    expect(segments.map(({ kind, spokenText, pauseAfterMs }) => ({
+      kind,
+      spokenText,
+      pauseAfterMs,
+    }))).toEqual([
+      { kind: "heading", spokenText: "Priorities", pauseAfterMs: 550 },
+      { kind: "list-item", spokenText: "exact pause", pauseAfterMs: 220 },
+      { kind: "list-item", spokenText: "faster audio", pauseAfterMs: 220 },
+      { kind: "quote", spokenText: "Preserve the listener's context.", pauseAfterMs: 420 },
+    ]);
+  });
+
+  it("infers a high-confidence heading when plain clipboard text retains only a line break", () => {
+    const segments = planTextForTTS(
+      "Why this matters\nThe listener needs a brief pause before this explanation begins.",
+    );
+
+    expect(segments.map(({ kind, spokenText, pauseAfterMs }) => ({
+      kind,
+      spokenText,
+      pauseAfterMs,
+    }))).toEqual([
+      { kind: "heading", spokenText: "Why this matters", pauseAfterMs: 550 },
+      {
+        kind: "paragraph",
+        spokenText: "The listener needs a brief pause before this explanation begins.",
+        pauseAfterMs: 420,
+      },
+    ]);
+  });
+
+  it("does not treat an ordinary hard-wrapped sentence as a heading", () => {
+    const segments = planTextForTTS(
+      "This thought wraps without punctuation\nand continues in lowercase on the next copied line.",
+    );
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0].kind).toBe("paragraph");
+    expect(segments[0].spokenText).toBe(
+      "This thought wraps without punctuation and continues in lowercase on the next copied line.",
+    );
+  });
+
+  it("announces and intelligently reads fenced code by default", () => {
+    const input = "Before.\n```ts\nstream.write(chunk);\n```\nAfter.";
+
+    const segments = planTextForTTS(input);
+
+    expect(segments.map((segment) => segment.spokenText)).toEqual([
+      "Before.",
+      "Code block.",
+      "stream dot write chunk",
+      "End code block.",
+      "After.",
+    ]);
+    expect(segments.find((segment) => segment.spokenText.includes("stream"))?.sourceText)
+      .toBe("stream.write(chunk);");
+  });
+
+  it("announces skipped code only when the setting is enabled", () => {
+    const input = "Before.\n```ts\nstream.write(chunk);\n```\nAfter.";
+    const segments = planTextForTTS(input, { skipCodeBlocks: true });
+
+    expect(segments.map((segment) => segment.spokenText)).toEqual([
+      "Before.",
+      "Code block skipped.",
+      "After.",
+    ]);
+  });
+
+  it("normalizes identifiers and operators without spelling every delimiter", () => {
+    expect(normalizeCodeForSpeech("if (activeSessionRef && request_id >= 2) {"))
+      .toBe("if active Session Ref and request id greater than or equal to 2");
+  });
+
+  it("bounds long inference segments at a safe word or clause boundary", () => {
+    const input = "Although generation can process a long sentence, the first audible sample should not wait for every supporting clause, and the playback controller should retain enough context to continue naturally without creating an oversized model input that fails on an experimental backend.";
+
+    const segments = planTextForTTS(input);
+
+    expect(segments.length).toBeGreaterThan(1);
+    expect(segments.every((segment) => segment.spokenText.length <= MAX_SPEECH_SEGMENT_CHARS))
+      .toBe(true);
+    expect(segments.map((segment) => segment.spokenText).join(" "))
+      .toBe(input);
+  });
+
+  it("uses sentence pauses internally and a paragraph pause at the block end", () => {
+    const segments = planTextForTTS("First sentence. Second sentence? Third sentence!");
+
+    expect(segments.map((segment) => segment.pauseAfterMs)).toEqual([120, 120, 420]);
+    expect(segments.map((segment) => segment.kind)).toEqual([
+      "sentence",
+      "sentence",
+      "paragraph",
+    ]);
+  });
+
+  it("recognizes an ellipsis boundary without splitting semantic versions", () => {
+    const segments = planTextForTTS("Ok.. Try v0.7.0 when it is ready.");
+
+    expect(segments.map((segment) => segment.spokenText)).toEqual([
+      "Okay..",
+      "Try v0.7.0 when it is ready.",
+    ]);
+    expect(segments[0].pauseAfterMs).toBe(320);
+  });
+
+  it("pronounces common chat shorthand as initialisms without changing meaning", () => {
+    const segments = planTextForTTS(
+      "idk, that looks wrong lol. TBH I expected more, but imo it helps.",
+    );
+
+    expect(segments.map((segment) => segment.spokenText)).toEqual([
+      "I D K, that looks wrong L O L.",
+      "T B H I expected more, but I M O it helps.",
+    ]);
+  });
+
+  it("removes inline markup while preserving meaningful text", () => {
+    const segments = planTextForTTS(
+      "Read **important** [documentation](https://example.com) and `request_id`.",
+    );
+
+    expect(segments[0].spokenText).toBe(
+      "Read important documentation and request_id.",
+    );
+  });
+
+  it("returns no segments for empty input", () => {
+    expect(planTextForTTS(" \n\n ")).toEqual([]);
+  });
+});

--- a/src/utils/speechPlanner.ts
+++ b/src/utils/speechPlanner.ts
@@ -1,0 +1,482 @@
+export const MAX_SPEECH_SEGMENT_CHARS = 140;
+
+export type SpeechSegmentKind =
+  | "heading"
+  | "paragraph"
+  | "sentence"
+  | "list-item"
+  | "quote"
+  | "code";
+
+export type SpeechSegment = {
+  id: string;
+  sourceText: string;
+  spokenText: string;
+  kind: SpeechSegmentKind;
+  pauseAfterMs: number;
+  sourceStart: number;
+  sourceEnd: number;
+};
+
+export type SpeechPlannerOptions = {
+  skipCodeBlocks?: boolean;
+};
+
+type SourceLine = {
+  text: string;
+  start: number;
+  end: number;
+};
+
+type MappedText = {
+  text: string;
+  sourcePositions: number[];
+};
+
+type SpeechBlock = {
+  kind: Exclude<SpeechSegmentKind, "sentence">;
+  lines: SourceLine[];
+  stripPrefix?: RegExp;
+};
+
+const FINAL_PAUSE_MS: Record<SpeechBlock["kind"], number> = {
+  heading: 550,
+  paragraph: 420,
+  "list-item": 220,
+  quote: 420,
+  code: 420,
+};
+
+const SPOKEN_SHORTHAND: Record<string, string> = {
+  idk: "I D K",
+  imo: "I M O",
+  lol: "L O L",
+  tbh: "T B H",
+};
+
+function sourceLines(input: string): SourceLine[] {
+  const lines: SourceLine[] = [];
+  const pattern = /[^\r\n]*(?:\r\n|\n|\r|$)/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(input)) !== null) {
+    if (match[0] === "") break;
+    const newlineLength = match[0].endsWith("\r\n")
+      ? 2
+      : /[\r\n]$/.test(match[0])
+        ? 1
+        : 0;
+    const text = newlineLength > 0 ? match[0].slice(0, -newlineLength) : match[0];
+    lines.push({ text, start: match.index, end: match.index + text.length });
+  }
+
+  return lines;
+}
+
+function isHeading(line: SourceLine): boolean {
+  return /^\s{0,3}#{1,6}\s+/.test(line.text);
+}
+
+function isListItem(line: SourceLine): boolean {
+  return /^\s*(?:[-*+]|\d+[.)])\s+/.test(line.text);
+}
+
+function isQuote(line: SourceLine): boolean {
+  return /^\s*>\s?/.test(line.text);
+}
+
+function isFence(line: SourceLine): boolean {
+  return /^\s*```/.test(line.text);
+}
+
+function isLikelyPlainHeading(lines: SourceLine[], index: number): boolean {
+  const line = lines[index];
+  const text = line?.text.trim() ?? "";
+  if (!text || text.length > 72 || /[.!?;:,]$/.test(text)) return false;
+
+  const words = text.split(/\s+/);
+  if (words.length > 9 || !/^\p{Lu}/u.test(text)) return false;
+  if (index > 0 && lines[index - 1].text.trim()) return false;
+
+  let nextIndex = index + 1;
+  while (nextIndex < lines.length && !lines[nextIndex].text.trim()) nextIndex += 1;
+  const nextText = lines[nextIndex]?.text.trim() ?? "";
+  return (
+    nextText.length >= Math.max(32, text.length + 12)
+    && /^\p{Lu}/u.test(nextText)
+    && /[.!?]["')\]]?$/.test(nextText)
+  );
+}
+
+function beginsSpecialBlock(lines: SourceLine[], index: number): boolean {
+  const line = lines[index];
+  return (
+    isHeading(line)
+    || isLikelyPlainHeading(lines, index)
+    || isListItem(line)
+    || isQuote(line)
+    || isFence(line)
+  );
+}
+
+function parseBlocks(input: string): SpeechBlock[] {
+  const lines = sourceLines(input);
+  const blocks: SpeechBlock[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (!line.text.trim()) {
+      index += 1;
+      continue;
+    }
+
+    if (isFence(line)) {
+      const codeLines = [line];
+      index += 1;
+      while (index < lines.length) {
+        codeLines.push(lines[index]);
+        const closing = isFence(lines[index]);
+        index += 1;
+        if (closing) break;
+      }
+      blocks.push({ kind: "code", lines: codeLines });
+      continue;
+    }
+
+    if (isHeading(line) || isLikelyPlainHeading(lines, index)) {
+      blocks.push({
+        kind: "heading",
+        lines: [line],
+        stripPrefix: isHeading(line) ? /^\s{0,3}#{1,6}\s+/ : undefined,
+      });
+      index += 1;
+      continue;
+    }
+
+    if (isListItem(line)) {
+      blocks.push({
+        kind: "list-item",
+        lines: [line],
+        stripPrefix: /^\s*(?:[-*+]|\d+[.)])\s+/,
+      });
+      index += 1;
+      continue;
+    }
+
+    if (isQuote(line)) {
+      const quoteLines = [];
+      while (index < lines.length && isQuote(lines[index])) {
+        quoteLines.push(lines[index]);
+        index += 1;
+      }
+      blocks.push({ kind: "quote", lines: quoteLines, stripPrefix: /^\s*>\s?/ });
+      continue;
+    }
+
+    const paragraphLines = [line];
+    index += 1;
+    while (
+      index < lines.length
+      && lines[index].text.trim()
+      && !beginsSpecialBlock(lines, index)
+    ) {
+      paragraphLines.push(lines[index]);
+      index += 1;
+    }
+    blocks.push({ kind: "paragraph", lines: paragraphLines });
+  }
+
+  return blocks;
+}
+
+function appendMappedText(
+  mapped: MappedText,
+  value: string,
+  sourceStart: number,
+): void {
+  let pendingSpacePosition: number | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    const sourcePosition = sourceStart + index;
+    if (/\s/.test(character)) {
+      if (mapped.text.length > 0) pendingSpacePosition = sourcePosition;
+      continue;
+    }
+    if (pendingSpacePosition !== null && !mapped.text.endsWith(" ")) {
+      mapped.text += " ";
+      mapped.sourcePositions.push(pendingSpacePosition);
+    }
+    pendingSpacePosition = null;
+    mapped.text += character;
+    mapped.sourcePositions.push(sourcePosition);
+  }
+}
+
+function mapBlock(block: SpeechBlock): MappedText {
+  const mapped: MappedText = { text: "", sourcePositions: [] };
+  for (const line of block.lines) {
+    let content = line.text;
+    let contentStart = line.start;
+    if (block.stripPrefix) {
+      const prefix = content.match(block.stripPrefix)?.[0] ?? "";
+      content = content.slice(prefix.length);
+      contentStart += prefix.length;
+    }
+
+    const leadingWhitespace = content.match(/^\s*/)?.[0].length ?? 0;
+    content = content.trim();
+    contentStart += leadingWhitespace;
+    if (!content) continue;
+
+    if (mapped.text.length > 0 && !mapped.text.endsWith(" ")) {
+      mapped.text += " ";
+      mapped.sourcePositions.push(Math.max(line.start - 1, 0));
+    }
+    appendMappedText(mapped, content, contentStart);
+  }
+  return mapped;
+}
+
+function trimRange(text: string, start: number, end: number): [number, number] | null {
+  while (start < end && /\s/.test(text[start])) start += 1;
+  while (end > start && /\s/.test(text[end - 1])) end -= 1;
+  return start < end ? [start, end] : null;
+}
+
+function sentenceRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let start = 0;
+  let index = 0;
+
+  while (index < text.length) {
+    if (/[.!?]/.test(text[index])) {
+      let end = index + 1;
+      while (end < text.length && /[.!?]/.test(text[end])) end += 1;
+      while (end < text.length && /["')\]]/.test(text[end])) end += 1;
+      if (end === text.length || /\s/.test(text[end])) {
+        const range = trimRange(text, start, end);
+        if (range) ranges.push(range);
+        start = end;
+      }
+      index = end;
+      continue;
+    }
+    index += 1;
+  }
+
+  const finalRange = trimRange(text, start, text.length);
+  if (finalRange) ranges.push(finalRange);
+  return ranges;
+}
+
+function findSafeCut(text: string, start: number, maximumEnd: number): number {
+  const minimumEnd = Math.min(start + 40, maximumEnd);
+  for (let index = maximumEnd; index >= minimumEnd; index -= 1) {
+    if (/[,;:—]/.test(text[index - 1])) return index;
+  }
+  for (let index = maximumEnd; index >= minimumEnd; index -= 1) {
+    if (/\s/.test(text[index - 1])) return index - 1;
+  }
+  return maximumEnd;
+}
+
+function boundRange(
+  text: string,
+  start: number,
+  end: number,
+  maximumLength: number,
+): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let cursor = start;
+  while (end - cursor > maximumLength) {
+    const cut = findSafeCut(text, cursor, cursor + maximumLength);
+    const range = trimRange(text, cursor, cut);
+    if (range) ranges.push(range);
+    cursor = cut;
+    while (cursor < end && /\s/.test(text[cursor])) cursor += 1;
+  }
+  const remainder = trimRange(text, cursor, end);
+  if (remainder) ranges.push(remainder);
+  return ranges;
+}
+
+function normalizeInlineMarkup(text: string): string {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, "$2")
+    .replace(/~~(.*?)~~/g, "$1")
+    .replace(/<[^>]*>/g, "")
+    .replace(/\bok\b/gi, "Okay")
+    .replace(/\b(?:idk|imo|lol|tbh)\b/gi, (match) => SPOKEN_SHORTHAND[match.toLowerCase()])
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const CODE_INITIALISMS: Record<string, string> = {
+  API: "A P I",
+  CPU: "C P U",
+  GPU: "G P U",
+  HTML: "H T M L",
+  HTTP: "H T T P",
+  HTTPS: "H T T P S",
+  ID: "I D",
+  SQL: "S Q L",
+  TTS: "T T S",
+  UI: "U I",
+  URL: "U R L",
+};
+
+function speakCodeIdentifier(identifier: string): string {
+  if (CODE_INITIALISMS[identifier]) return CODE_INITIALISMS[identifier];
+  return identifier
+    .replace(/_/g, " ")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+}
+
+export function normalizeCodeForSpeech(codeLine: string): string {
+  let spoken = codeLine.trim();
+  if (!spoken) return "";
+  spoken = spoken
+    .replace(/^\/\/\s*/, "Comment, ")
+    .replace(/^#\s*/, "Comment, ")
+    .replace(/[A-Za-z_$][\w$]*/g, speakCodeIdentifier)
+    .replace(/!==/g, " does not strictly equal ")
+    .replace(/===/g, " strictly equals ")
+    .replace(/!=/g, " does not equal ")
+    .replace(/==/g, " equals ")
+    .replace(/=>/g, " maps to ")
+    .replace(/>=/g, " greater than or equal to ")
+    .replace(/<=/g, " less than or equal to ")
+    .replace(/&&/g, " and ")
+    .replace(/\|\|/g, " or ")
+    .replace(/(?<=[A-Za-z_$])\.(?=[A-Za-z_$])/g, " dot ")
+    .replace(/=/g, " equals ")
+    .replace(/\+/g, " plus ")
+    .replace(/\*/g, " times ")
+    .replace(/\//g, " slash ")
+    .replace(/[()[\]{};,:'"`]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return spoken;
+}
+
+function codeSegments(
+  input: string,
+  block: SpeechBlock,
+  firstId: number,
+  skipCodeBlocks: boolean,
+): SpeechSegment[] {
+  const sourceStart = block.lines[0].start;
+  const sourceEnd = block.lines[block.lines.length - 1].end;
+  if (skipCodeBlocks) {
+    return [{
+      id: `segment-${firstId}`,
+      sourceText: input.slice(sourceStart, sourceEnd),
+      spokenText: "Code block skipped.",
+      kind: "code",
+      pauseAfterMs: FINAL_PAUSE_MS.code,
+      sourceStart,
+      sourceEnd,
+    }];
+  }
+
+  const hasClosingFence = block.lines.length > 1 && isFence(block.lines[block.lines.length - 1]);
+  const bodyLines = block.lines.slice(1, hasClosingFence ? -1 : undefined);
+  const segments: SpeechSegment[] = [{
+    id: `segment-${firstId}`,
+    sourceText: input.slice(block.lines[0].start, block.lines[0].end),
+    spokenText: "Code block.",
+    kind: "code",
+    pauseAfterMs: 220,
+    sourceStart: block.lines[0].start,
+    sourceEnd: block.lines[0].end,
+  }];
+
+  for (const line of bodyLines) {
+    const spokenLine = normalizeCodeForSpeech(line.text);
+    if (!spokenLine) continue;
+    const chunks = boundRange(spokenLine, 0, spokenLine.length, MAX_SPEECH_SEGMENT_CHARS);
+    for (const [start, end] of chunks) {
+      segments.push({
+        id: `segment-${firstId + segments.length}`,
+        sourceText: input.slice(line.start, line.end),
+        spokenText: spokenLine.slice(start, end),
+        kind: "code",
+        pauseAfterMs: 180,
+        sourceStart: line.start,
+        sourceEnd: line.end,
+      });
+    }
+  }
+
+  const closingLine = hasClosingFence
+    ? block.lines[block.lines.length - 1]
+    : block.lines[block.lines.length - 1];
+  segments.push({
+    id: `segment-${firstId + segments.length}`,
+    sourceText: input.slice(closingLine.start, closingLine.end),
+    spokenText: "End code block.",
+    kind: "code",
+    pauseAfterMs: FINAL_PAUSE_MS.code,
+    sourceStart: closingLine.start,
+    sourceEnd: closingLine.end,
+  });
+  return segments;
+}
+
+function internalPauseMs(spokenText: string): number {
+  // Informal fragments such as “Okay..” and “What if..” carry an explicit
+  // thought break that should be longer than an ordinary sentence boundary.
+  return /\.{2,}["')\]]?$/.test(spokenText) ? 320 : 120;
+}
+
+function segmentsForBlock(
+  input: string,
+  block: SpeechBlock,
+  firstId: number,
+  options: SpeechPlannerOptions,
+): SpeechSegment[] {
+  if (block.kind === "code") {
+    return codeSegments(input, block, firstId, options.skipCodeBlocks ?? false);
+  }
+
+  const mapped = mapBlock(block);
+  const ranges = sentenceRanges(mapped.text).flatMap(([start, end]) =>
+    boundRange(mapped.text, start, end, MAX_SPEECH_SEGMENT_CHARS)
+  );
+
+  return ranges.flatMap(([start, end], index) => {
+    const spokenText = normalizeInlineMarkup(mapped.text.slice(start, end));
+    if (!spokenText) return [];
+    const sourceStart = mapped.sourcePositions[start];
+    const sourceEnd = mapped.sourcePositions[end - 1] + 1;
+    const isLast = index === ranges.length - 1;
+    return [{
+      id: `segment-${firstId + index}`,
+      sourceText: input.slice(sourceStart, sourceEnd),
+      spokenText,
+      kind: ranges.length > 1 && !isLast ? "sentence" : block.kind,
+      pauseAfterMs: isLast ? FINAL_PAUSE_MS[block.kind] : internalPauseMs(spokenText),
+      sourceStart,
+      sourceEnd,
+    } satisfies SpeechSegment];
+  });
+}
+
+export function planTextForTTS(
+  input: string,
+  options: SpeechPlannerOptions = {},
+): SpeechSegment[] {
+  if (!input.trim()) return [];
+
+  const segments: SpeechSegment[] = [];
+  for (const block of parseBlocks(input)) {
+    const planned = segmentsForBlock(input, block, segments.length, options);
+    segments.push(...planned);
+  }
+  return segments.map((segment, index) => ({ ...segment, id: `segment-${index}` }));
+}

--- a/src/utils/ttsEvents.test.ts
+++ b/src/utils/ttsEvents.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  eventBelongsToRequest,
+  statusForTtsEvent,
+  type TtsEventName,
+  type TtsLifecycleEvent,
+} from "./ttsEvents";
+
+function lifecycleEvent(event: TtsEventName, requestId = "active"): TtsLifecycleEvent {
+  return {
+    schemaVersion: 1,
+    requestId,
+    event,
+    timestampMs: 42,
+    data: {},
+  };
+}
+
+describe("TTS lifecycle events", () => {
+  it("maps lifecycle stages to reader status", () => {
+    expect(statusForTtsEvent(lifecycleEvent("request_received"))).toBe("Generating");
+    expect(statusForTtsEvent(lifecycleEvent("engine_ready"))).toBeNull();
+    expect(statusForTtsEvent(lifecycleEvent("inference_started"))).toBeNull();
+    expect(statusForTtsEvent(lifecycleEvent("chunk_ready"))).toBeNull();
+    expect(statusForTtsEvent(lifecycleEvent("speed_changed"))).toBeNull();
+    expect(statusForTtsEvent(lifecycleEvent("playback_started"))).toBe("Speaking");
+    expect(statusForTtsEvent(lifecycleEvent("paused"))).toBe("Paused");
+    expect(statusForTtsEvent(lifecycleEvent("resumed"))).toBe("Speaking");
+    expect(statusForTtsEvent(lifecycleEvent("cancelled"))).toBe("Idle");
+    expect(statusForTtsEvent(lifecycleEvent("playback_finished"))).toBe("Idle");
+    expect(statusForTtsEvent(lifecycleEvent("error"))).toBe("TTS Error");
+  });
+
+  it("rejects lifecycle events from stale playback sessions", () => {
+    expect(eventBelongsToRequest(lifecycleEvent("playback_finished"), "active")).toBe(true);
+    expect(eventBelongsToRequest(lifecycleEvent("playback_finished", "stale"), "active")).toBe(false);
+    expect(eventBelongsToRequest(lifecycleEvent("playback_finished"), null)).toBe(false);
+  });
+});

--- a/src/utils/ttsEvents.ts
+++ b/src/utils/ttsEvents.ts
@@ -1,0 +1,55 @@
+export type TtsStatus = "Idle" | "Generating" | "Speaking" | "Paused" | "TTS Error";
+
+export type TtsEventName =
+  | "request_received"
+  | "engine_ready"
+  | "inference_started"
+  | "chunk_ready"
+  | "playback_started"
+  | "paused"
+  | "resumed"
+  | "speed_changed"
+  | "cancelled"
+  | "playback_finished"
+  | "error";
+
+export type TtsLifecycleEvent = {
+  schemaVersion: 1;
+  requestId: string;
+  event: TtsEventName;
+  timestampMs: number;
+  data: Record<string, unknown>;
+};
+
+export function statusForTtsEvent(event: TtsLifecycleEvent): TtsStatus | null {
+  switch (event.event) {
+    case "request_received":
+      return "Generating";
+    case "engine_ready":
+    case "inference_started":
+    case "chunk_ready":
+    case "speed_changed":
+      // Informational stages must not move a streaming request back from
+      // Speaking to Generating when later chunks arrive.
+      return null;
+    case "playback_started":
+    case "resumed":
+      return "Speaking";
+    case "paused":
+      return "Paused";
+    case "cancelled":
+    case "playback_finished":
+      return "Idle";
+    case "error":
+      return "TTS Error";
+    default:
+      return null;
+  }
+}
+
+export function eventBelongsToRequest(
+  event: TtsLifecycleEvent,
+  activeRequestId: string | null,
+): boolean {
+  return activeRequestId !== null && event.requestId === activeRequestId;
+}

--- a/tests/fixtures/reader_quality_v1.json
+++ b/tests/fixtures/reader_quality_v1.json
@@ -1,0 +1,187 @@
+{
+  "schemaVersion": 1,
+  "name": "Kokoro Clipboard TTS reader quality corpus",
+  "description": "Source text fixtures for deterministic planning, listening comparisons, and latency benchmarks. Expected spoken forms are added as the corresponding product decisions are approved.",
+  "cases": [
+    {
+      "id": "structure-paragraph-breaks",
+      "category": "structure",
+      "priority": "critical",
+      "input": "The first idea needs time to land.\n\nThe second idea should begin after a noticeable pause.",
+      "concerns": ["paragraph-boundary", "pause-duration"]
+    },
+    {
+      "id": "structure-heading-and-body",
+      "category": "structure",
+      "priority": "high",
+      "input": "## Why this matters\nA heading should not run directly into its explanation.",
+      "concerns": ["markdown-heading", "section-boundary"]
+    },
+    {
+      "id": "structure-plain-heading-linebreak",
+      "category": "structure",
+      "priority": "critical",
+      "input": "Why this matters\nThe listener needs a brief pause before this explanation begins.",
+      "expectedSpokenSegments": ["Why this matters", "The listener needs a brief pause before this explanation begins."],
+      "concerns": ["plain-text-heading-inference", "single-line-break", "section-boundary"]
+    },
+    {
+      "id": "structure-list-items",
+      "category": "structure",
+      "priority": "critical",
+      "input": "We need three things:\n- exact pause and resume\n- faster first audio\n- clearer progress feedback",
+      "concerns": ["list-boundary", "enumeration-prosody"]
+    },
+    {
+      "id": "structure-quote",
+      "category": "structure",
+      "priority": "medium",
+      "input": "She paused before answering.\n\n> I don't think that follows from the evidence.\n\nThen the room went quiet.",
+      "concerns": ["blockquote", "speaker-transition"]
+    },
+    {
+      "id": "chat-ok-ellipsis",
+      "category": "chat",
+      "priority": "critical",
+      "input": "Ok.. I see what you mean. But what if we tried it another way?",
+      "expectedSpokenSegments": ["Okay..", "I see what you mean.", "But what if we tried it another way?"],
+      "concerns": ["okay-pronunciation", "ellipsis", "thought-boundary"]
+    },
+    {
+      "id": "chat-what-if-fragment",
+      "category": "chat",
+      "priority": "critical",
+      "input": "What if.. instead of waiting for the whole response, we started with the first clause?",
+      "expectedSpokenSegments": ["What if..", "instead of waiting for the whole response, we started with the first clause?"],
+      "concerns": ["fragment-pause", "ellipsis", "stress"]
+    },
+    {
+      "id": "chat-idk-lol",
+      "category": "chat",
+      "priority": "critical",
+      "input": "idk, that result looks wrong lol. Can you check it again?",
+      "expectedSpokenSegments": ["I D K, that result looks wrong L O L.", "Can you check it again?"],
+      "concerns": ["shorthand", "acronym-expansion", "sentence-tone"]
+    },
+    {
+      "id": "chat-mixed-case-shorthand",
+      "category": "chat",
+      "priority": "high",
+      "input": "TBH I expected a different answer, but imo this is still useful.",
+      "expectedSpokenSegments": ["T B H I expected a different answer, but I M O this is still useful."],
+      "concerns": ["case-insensitive-shorthand", "acronym-boundaries"]
+    },
+    {
+      "id": "acronyms-common-technical",
+      "category": "acronyms",
+      "priority": "critical",
+      "input": "The API sends JSON over HTTP, while the GPU runs the TTS model.",
+      "concerns": ["initialism", "known-acronym", "stress"]
+    },
+    {
+      "id": "acronyms-word-collisions",
+      "category": "acronyms",
+      "priority": "high",
+      "input": "The US office asked us to update the policy.",
+      "concerns": ["case-sensitive-meaning", "word-boundary"]
+    },
+    {
+      "id": "numbers-currency-percent",
+      "category": "numbers",
+      "priority": "critical",
+      "input": "The total increased from $12.50 to $19.99, or about 59.9%.",
+      "concerns": ["currency", "decimal", "percentage"]
+    },
+    {
+      "id": "numbers-date-and-time",
+      "category": "numbers",
+      "priority": "critical",
+      "input": "The meeting is on 2026-07-25 at 3:05 p.m.",
+      "concerns": ["iso-date", "time", "abbreviation"]
+    },
+    {
+      "id": "numbers-version-and-range",
+      "category": "numbers",
+      "priority": "high",
+      "input": "Upgrade from v0.6.3 to v0.7.0, then test speeds from 0.5x to 2.0x.",
+      "concerns": ["semantic-version", "decimal", "range", "multiplier"]
+    },
+    {
+      "id": "numbers-long-digits",
+      "category": "numbers",
+      "priority": "high",
+      "input": "Use confirmation code 408271 and ticket number 1200459931.",
+      "concerns": ["digit-grouping", "identifier-not-cardinal"]
+    },
+    {
+      "id": "technical-url-email-path",
+      "category": "technical",
+      "priority": "critical",
+      "input": "Open https://example.com/docs, email support@example.com, or inspect /Users/me/project/app.ts.",
+      "concerns": ["url-policy", "email-policy", "filesystem-path"]
+    },
+    {
+      "id": "technical-identifiers",
+      "category": "technical",
+      "priority": "critical",
+      "input": "Call getUserProfile, then assign request_id to activeSessionRef.",
+      "concerns": ["camel-case", "snake-case", "identifier-boundary"]
+    },
+    {
+      "id": "technical-units",
+      "category": "technical",
+      "priority": "high",
+      "input": "The buffer contains 1,200 samples at 24 kHz and represents 50 ms of audio.",
+      "concerns": ["thousands-separator", "unit", "abbreviation"]
+    },
+    {
+      "id": "code-inline",
+      "category": "code",
+      "priority": "high",
+      "input": "Set `playbackRate = 1.25` before calling `stream.start()`.",
+      "concerns": ["inline-code", "identifier", "decimal"]
+    },
+    {
+      "id": "code-fenced-block",
+      "category": "code",
+      "priority": "critical",
+      "input": "Run this example:\n```python\nfor chunk in audio_queue:\n    stream.write(chunk)\n```\nThen confirm playback finishes.",
+      "concerns": ["code-policy", "fenced-code", "transition-back-to-prose"]
+    },
+    {
+      "id": "punctuation-parenthetical-dash",
+      "category": "punctuation",
+      "priority": "high",
+      "input": "The default engine—Kokoro—is stable (and completely local), but it is not always natural.",
+      "concerns": ["em-dash", "parenthetical", "clause-stress"]
+    },
+    {
+      "id": "punctuation-question-sequence",
+      "category": "punctuation",
+      "priority": "high",
+      "input": "Did it pause? Did it resume from the same place? Did the speed actually change?",
+      "concerns": ["repeated-question-prosody", "sentence-boundary"]
+    },
+    {
+      "id": "long-form-multiple-thoughts",
+      "category": "long-form",
+      "priority": "critical",
+      "input": "A fast reader is useful only when it remains understandable. If each sentence arrives with the same rhythm, the listener has no indication which ideas are supporting details and which ones are conclusions.\n\nThe system should therefore preserve paragraph structure, produce the first clause quickly, and continue generating later sentences while playback is already underway.",
+      "concerns": ["long-form-flow", "paragraph-boundary", "lookahead", "thought-digestion"]
+    },
+    {
+      "id": "long-form-single-sentence",
+      "category": "long-form",
+      "priority": "critical",
+      "input": "Although the model can generate a long sentence as one chunk, doing so delays the first audible sample, makes interruption less precise, and leaves the listener waiting even when the opening clause could already have been spoken.",
+      "concerns": ["clause-segmentation", "first-audio-latency", "prosody-context"]
+    },
+    {
+      "id": "privacy-sensitive-shape",
+      "category": "privacy",
+      "priority": "critical",
+      "input": "Account reference AB-2048-XY should be read locally and must never appear in release logs.",
+      "concerns": ["identifier", "release-log-redaction", "offline-only"]
+    }
+  ]
+}

--- a/third_party/sonic/LICENSE
+++ b/third_party/sonic/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/sonic/README.md
+++ b/third_party/sonic/README.md
@@ -1,0 +1,7 @@
+# Sonic DSP
+
+Vendored from [waywardgeek/sonic](https://github.com/waywardgeek/sonic) at commit `b93885dcb70aae50c6f76b0fe4e0868f029a077e`.
+
+`sonic.c` and `sonic.h` are unmodified upstream files. Sonic is designed for real-time speech-rate changes and is distributed under the Apache License 2.0; see `LICENSE`.
+
+`sonic_wrapper.c` is project-owned glue that exposes an explicit shared-library ABI for Python `ctypes`, including Windows DLL exports.

--- a/third_party/sonic/sonic.c
+++ b/third_party/sonic/sonic.c
@@ -1,0 +1,1247 @@
+/* Sonic library
+   Copyright 2010
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "sonic.h"
+
+#include <limits.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+    The following code was used to generate the following sinc lookup table.
+
+    #include <limits.h>
+    #include <math.h>
+    #include <stdio.h>
+
+    double findHannWeight(int N, double x) {
+        return 0.5*(1.0 - cos(2*M_PI*x/N));
+    }
+
+    double findSincCoefficient(int N, double x) {
+        double hannWindowWeight = findHannWeight(N, x);
+        double sincWeight;
+
+        x -= N/2.0;
+        if (x > 1e-9 || x < -1e-9) {
+            sincWeight = sin(M_PI*x)/(M_PI*x);
+        } else {
+            sincWeight = 1.0;
+        }
+        return hannWindowWeight*sincWeight;
+    }
+
+    int main() {
+        double x;
+        int i;
+        int N = 12;
+
+        for (i = 0, x = 0.0; x <= N; x += 0.02, i++) {
+            printf("%u %d\n", i, (int)(SHRT_MAX*findSincCoefficient(N, x)));
+        }
+        return 0;
+    }
+*/
+
+#define CLAMP(val, min, max) \
+  ((val) < (min) ? (min) : (val) > (max) ? (max) : (val))
+
+/* The number of points to use in the sinc FIR filter for resampling. */
+#define SINC_FILTER_POINTS \
+  12 /* I am not able to hear improvement with higher N. */
+#define SINC_TABLE_SIZE 601
+
+/* Lookup table for windowed sinc function of SINC_FILTER_POINTS points. */
+static short sincTable[SINC_TABLE_SIZE] = {
+    0,     0,     0,     0,     0,     0,     0,     -1,    -1,    -2,    -2,
+    -3,    -4,    -6,    -7,    -9,    -10,   -12,   -14,   -17,   -19,   -21,
+    -24,   -26,   -29,   -32,   -34,   -37,   -40,   -42,   -44,   -47,   -48,
+    -50,   -51,   -52,   -53,   -53,   -53,   -52,   -50,   -48,   -46,   -43,
+    -39,   -34,   -29,   -22,   -16,   -8,    0,     9,     19,    29,    41,
+    53,    65,    79,    92,    107,   121,   137,   152,   168,   184,   200,
+    215,   231,   247,   262,   276,   291,   304,   317,   328,   339,   348,
+    357,   363,   369,   372,   374,   375,   373,   369,   363,   355,   345,
+    332,   318,   300,   281,   259,   234,   208,   178,   147,   113,   77,
+    39,    0,     -41,   -85,   -130,  -177,  -225,  -274,  -324,  -375,  -426,
+    -478,  -530,  -581,  -632,  -682,  -731,  -779,  -825,  -870,  -912,  -951,
+    -989,  -1023, -1053, -1080, -1104, -1123, -1138, -1149, -1154, -1155, -1151,
+    -1141, -1125, -1105, -1078, -1046, -1007, -963,  -913,  -857,  -796,  -728,
+    -655,  -576,  -492,  -403,  -309,  -210,  -107,  0,     111,   225,   342,
+    462,   584,   708,   833,   958,   1084,  1209,  1333,  1455,  1575,  1693,
+    1807,  1916,  2022,  2122,  2216,  2304,  2384,  2457,  2522,  2579,  2625,
+    2663,  2689,  2706,  2711,  2705,  2687,  2657,  2614,  2559,  2491,  2411,
+    2317,  2211,  2092,  1960,  1815,  1658,  1489,  1308,  1115,  912,   698,
+    474,   241,   0,     -249,  -506,  -769,  -1037, -1310, -1586, -1864, -2144,
+    -2424, -2703, -2980, -3254, -3523, -3787, -4043, -4291, -4529, -4757, -4972,
+    -5174, -5360, -5531, -5685, -5819, -5935, -6029, -6101, -6150, -6175, -6175,
+    -6149, -6096, -6015, -5905, -5767, -5599, -5401, -5172, -4912, -4621, -4298,
+    -3944, -3558, -3141, -2693, -2214, -1705, -1166, -597,  0,     625,   1277,
+    1955,  2658,  3386,  4135,  4906,  5697,  6506,  7332,  8173,  9027,  9893,
+    10769, 11654, 12544, 13439, 14335, 15232, 16128, 17019, 17904, 18782, 19649,
+    20504, 21345, 22170, 22977, 23763, 24527, 25268, 25982, 26669, 27327, 27953,
+    28547, 29107, 29632, 30119, 30569, 30979, 31349, 31678, 31964, 32208, 32408,
+    32565, 32677, 32744, 32767, 32744, 32677, 32565, 32408, 32208, 31964, 31678,
+    31349, 30979, 30569, 30119, 29632, 29107, 28547, 27953, 27327, 26669, 25982,
+    25268, 24527, 23763, 22977, 22170, 21345, 20504, 19649, 18782, 17904, 17019,
+    16128, 15232, 14335, 13439, 12544, 11654, 10769, 9893,  9027,  8173,  7332,
+    6506,  5697,  4906,  4135,  3386,  2658,  1955,  1277,  625,   0,     -597,
+    -1166, -1705, -2214, -2693, -3141, -3558, -3944, -4298, -4621, -4912, -5172,
+    -5401, -5599, -5767, -5905, -6015, -6096, -6149, -6175, -6175, -6150, -6101,
+    -6029, -5935, -5819, -5685, -5531, -5360, -5174, -4972, -4757, -4529, -4291,
+    -4043, -3787, -3523, -3254, -2980, -2703, -2424, -2144, -1864, -1586, -1310,
+    -1037, -769,  -506,  -249,  0,     241,   474,   698,   912,   1115,  1308,
+    1489,  1658,  1815,  1960,  2092,  2211,  2317,  2411,  2491,  2559,  2614,
+    2657,  2687,  2705,  2711,  2706,  2689,  2663,  2625,  2579,  2522,  2457,
+    2384,  2304,  2216,  2122,  2022,  1916,  1807,  1693,  1575,  1455,  1333,
+    1209,  1084,  958,   833,   708,   584,   462,   342,   225,   111,   0,
+    -107,  -210,  -309,  -403,  -492,  -576,  -655,  -728,  -796,  -857,  -913,
+    -963,  -1007, -1046, -1078, -1105, -1125, -1141, -1151, -1155, -1154, -1149,
+    -1138, -1123, -1104, -1080, -1053, -1023, -989,  -951,  -912,  -870,  -825,
+    -779,  -731,  -682,  -632,  -581,  -530,  -478,  -426,  -375,  -324,  -274,
+    -225,  -177,  -130,  -85,   -41,   0,     39,    77,    113,   147,   178,
+    208,   234,   259,   281,   300,   318,   332,   345,   355,   363,   369,
+    373,   375,   374,   372,   369,   363,   357,   348,   339,   328,   317,
+    304,   291,   276,   262,   247,   231,   215,   200,   184,   168,   152,
+    137,   121,   107,   92,    79,    65,    53,    41,    29,    19,    9,
+    0,     -8,    -16,   -22,   -29,   -34,   -39,   -43,   -46,   -48,   -50,
+    -52,   -53,   -53,   -53,   -52,   -51,   -50,   -48,   -47,   -44,   -42,
+    -40,   -37,   -34,   -32,   -29,   -26,   -24,   -21,   -19,   -17,   -14,
+    -12,   -10,   -9,    -7,    -6,    -4,    -3,    -2,    -2,    -1,    -1,
+    0,     0,     0,     0,     0,     0,     0};
+
+/* These functions allocate out of a static array rather than calling
+   calloc/realloc/free if the NO_MALLOC flag is defined.  Otherwise, call
+   calloc/realloc/free as usual.  This is useful for running on small
+   microcontrollers. */
+#ifndef SONIC_NO_MALLOC
+
+/* Just call calloc. */
+static void* sonicCalloc(int num, int size) { return calloc(num, size); }
+
+/* Just call realloc */
+static void* sonicRealloc(void* p, int oldNum, int newNum, int size) {
+  return realloc(p, newNum * size);
+}
+
+/* Just call free. */
+static void sonicFree(void* p) { free(p); }
+
+#else
+
+#ifndef SONIC_MAX_MEMORY
+/* Large enough for speedup/slowdown at 8KHz, 16-bit mono samples/second. */
+#define SONIC_MAX_MEMORY (16 * 1024)
+#endif
+
+/* This static buffer is used to hold data allocated for the sonicStream struct
+   and its buffers.  There should never be more than one sonicStream in use at a
+   time when using SONIC_NO_MALLOC mode.  Calls to realloc move the data to the
+   end of memoryBuffer.  Calls to free reset the memory buffer to empty. */
+static void*
+    memoryBufferAligned[(SONIC_MAX_MEMORY + sizeof(void) - 1) / sizeof(void*)];
+static unsigned char* memoryBuffer = (unsigned char*)memoryBufferAligned;
+static int memoryBufferPos = 0;
+
+/* Allocate elements from a static memory buffer. */
+static void* sonicCalloc(int num, int size) {
+  int len = num * size;
+
+  if (memoryBufferPos + len > SONIC_MAX_MEMORY) {
+    return 0;
+  }
+  unsigned char* p = memoryBuffer + memoryBufferPos;
+  memoryBufferPos += len;
+  memset(p, 0, len);
+  return p;
+}
+
+/* Preferably, SONIC_MAX_MEMORY has been set large enough that this is never
+ * called. */
+static void* sonicRealloc(void* p, int oldNum, int newNum, int size) {
+  if (newNum <= oldNum) {
+    return p;
+  }
+  void* newBuffer = sonicCalloc(newNum, size);
+  if (newBuffer == NULL) {
+    return NULL;
+  }
+  memcpy(newBuffer, p, oldNum * size);
+  return newBuffer;
+}
+
+/* Reset memoryBufferPos to 0.  We asssume all data is freed at the same time.
+ */
+static void sonicFree(void* p) { memoryBufferPos = 0; }
+
+#endif
+
+struct sonicStreamStruct {
+#ifdef SONIC_SPECTROGRAM
+  sonicSpectrogram spectrogram;
+#endif /* SONIC_SPECTROGRAM */
+  short* inputBuffer;
+  short* outputBuffer;
+  short* pitchBuffer;
+  short* downSampleBuffer;
+  void* userData;
+  float speed;
+  float volume;
+  float pitch;
+  float rate;
+  /* The point of the following 3 new variables is to gracefully handle rapidly
+     changing input speed.
+
+     samplePeriod is just 1.0/sampleRate.  It is used in accumulating
+     inputPlayTime, which is how long we expect the total time should be to play
+     the current input samples in the input buffer.  timeError keeps track of
+     the error in play time created when playing < 2.0X speed, where we either
+     insert or delete a whole pitch period.  This can cause the output generated
+     from the input to be off in play time by up to a pitch period.  timeError
+     replaces PICOLA's concept of the number of samples to play unmodified after
+     a pitch period insertion or deletion.  If speeding up, and the error is >=
+     0.0, then remove a pitch period, and play samples unmodified until
+     timeError is >= 0 again.  If slowing down, and the error is <= 0.0,
+     then add a pitch period, and play samples unmodified until timeError is <=
+     0 again. */
+  float samplePeriod; /* How long each output sample takes to play. */
+  /* How long we expect the entire input buffer to take to play. */
+  float inputPlayTime;
+  /* The difference in when the latest output sample was played vs when we
+   * wanted.  */
+  float timeError;
+  int oldRatePosition;
+  int newRatePosition;
+  int quality;
+  int numChannels;
+  int inputBufferSize;
+  int pitchBufferSize;
+  int outputBufferSize;
+  int numInputSamples;
+  int numOutputSamples;
+  int numPitchSamples;
+  int minPeriod;
+  int maxPeriod;
+  int maxRequired;
+  int remainingInputToCopy;
+  int sampleRate;
+  int prevPeriod;
+  int prevMinDiff;
+};
+
+/* Attach user data to the stream. */
+void sonicSetUserData(sonicStream stream, void* userData) {
+  stream->userData = userData;
+}
+
+/* Retrieve user data attached to the stream. */
+void* sonicGetUserData(sonicStream stream) { return stream->userData; }
+
+#ifdef SONIC_SPECTROGRAM
+
+/* Compute a spectrogram on the fly. */
+void sonicComputeSpectrogram(sonicStream stream) {
+  stream->spectrogram = sonicCreateSpectrogram(stream->sampleRate);
+  /* Force changeSpeed to be called to compute the spectrogram. */
+  sonicSetSpeed(stream, 2.0);
+}
+
+/* Get the spectrogram. */
+sonicSpectrogram sonicGetSpectrogram(sonicStream stream) {
+  return stream->spectrogram;
+}
+
+#endif
+
+/* Scale the samples by the factor. */
+static void scaleSamples(short* samples, int numSamples, float volume) {
+  /* This is 24-bit integer and 8-bit fraction fixed-point representation. */
+  int fixedPointVolume = volume * 256.0f;
+  int value;
+
+  while (numSamples--) {
+    value = (*samples * fixedPointVolume) >> 8;
+    if (value > 32767) {
+      value = 32767;
+    } else if (value < -32767) {
+      value = -32767;
+    }
+    *samples++ = value;
+  }
+}
+
+/* Get the speed of the stream. */
+float sonicGetSpeed(sonicStream stream) { return stream->speed; }
+
+/* Set the speed of the stream. */
+void sonicSetSpeed(sonicStream stream, float speed) {
+  stream->speed = CLAMP(speed, SONIC_MIN_SPEED, SONIC_MAX_SPEED);
+}
+
+/* Get the pitch of the stream. */
+float sonicGetPitch(sonicStream stream) { return stream->pitch; }
+
+/* Set the pitch of the stream. */
+void sonicSetPitch(sonicStream stream, float pitch) {
+  stream->pitch = CLAMP(pitch, SONIC_MIN_PITCH_SETTING, SONIC_MAX_PITCH_SETTING);
+}
+
+/* Get the rate of the stream. */
+float sonicGetRate(sonicStream stream) { return stream->rate; }
+
+/* Set the playback rate of the stream. This scales pitch and speed at the same
+   time. */
+void sonicSetRate(sonicStream stream, float rate) {
+  stream->rate = CLAMP(rate, SONIC_MIN_RATE, SONIC_MAX_RATE);
+
+  stream->oldRatePosition = 0;
+  stream->newRatePosition = 0;
+}
+
+/* DEPRECATED.  Get the vocal chord pitch setting. */
+int sonicGetChordPitch(sonicStream stream) { return 0; }
+
+/* DEPRECATED. Set the vocal chord mode for pitch computation.  Default is off.
+ */
+void sonicSetChordPitch(sonicStream stream, int useChordPitch) {}
+
+/* Get the quality setting. */
+int sonicGetQuality(sonicStream stream) { return stream->quality; }
+
+/* Set the "quality".  Default 0 is virtually as good as 1, but very much
+   faster. */
+void sonicSetQuality(sonicStream stream, int quality) {
+  stream->quality = quality != 0? 1 : 0;
+}
+
+/* Get the scaling factor of the stream. */
+float sonicGetVolume(sonicStream stream) { return stream->volume; }
+
+/* Set the scaling factor of the stream. */
+void sonicSetVolume(sonicStream stream, float volume) {
+  stream->volume = CLAMP(volume, SONIC_MIN_VOLUME, SONIC_MAX_VOLUME);
+}
+
+/* Free stream buffers. */
+static void freeStreamBuffers(sonicStream stream) {
+  if (stream->inputBuffer != NULL) {
+    sonicFree(stream->inputBuffer);
+  }
+  if (stream->outputBuffer != NULL) {
+    sonicFree(stream->outputBuffer);
+  }
+  if (stream->pitchBuffer != NULL) {
+    sonicFree(stream->pitchBuffer);
+  }
+  if (stream->downSampleBuffer != NULL) {
+    sonicFree(stream->downSampleBuffer);
+  }
+}
+
+/* Destroy the sonic stream. */
+void sonicDestroyStream(sonicStream stream) {
+#ifdef SONIC_SPECTROGRAM
+  if (stream->spectrogram != NULL) {
+    sonicDestroySpectrogram(stream->spectrogram);
+  }
+#endif /* SONIC_SPECTROGRAM */
+  freeStreamBuffers(stream);
+  sonicFree(stream);
+}
+
+/* Compute the number of samples to skip to down-sample the input. */
+static int computeSkip(sonicStream stream, int sampleRate) {
+  int skip = 1;
+  if (sampleRate > SONIC_AMDF_FREQ && stream->quality == 0) {
+    skip = sampleRate / SONIC_AMDF_FREQ;
+  }
+  return skip;
+}
+
+/* Allocate stream buffers. */
+static int allocateStreamBuffers(sonicStream stream, int sampleRate,
+                                 int numChannels) {
+  int minPeriod = sampleRate / SONIC_MAX_PITCH;
+  int maxPeriod = sampleRate / SONIC_MIN_PITCH;
+  int maxRequired = 2 * maxPeriod;
+
+  /* Allocate 25% more than needed so we hopefully won't grow. */
+  stream->inputBufferSize = maxRequired + (maxRequired >> 2);
+
+  stream->inputBuffer =
+      (short*)sonicCalloc(stream->inputBufferSize, sizeof(short) * numChannels);
+  if (stream->inputBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  /* Allocate 25% more than needed so we hopefully won't grow. */
+  stream->outputBufferSize = maxRequired + (maxRequired >> 2);
+  stream->outputBuffer = (short*)sonicCalloc(stream->outputBufferSize,
+                                             sizeof(short) * numChannels);
+  if (stream->outputBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  /* Allocate 25% more than needed so we hopefully won't grow. */
+  stream->pitchBufferSize = maxRequired + (maxRequired >> 2);
+  stream->pitchBuffer =
+      (short*)sonicCalloc(stream->pitchBufferSize, sizeof(short) * numChannels);
+  if (stream->pitchBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  int downSampleBufferSize = maxRequired;
+  stream->downSampleBuffer =
+      (short*)sonicCalloc(downSampleBufferSize, sizeof(short));
+  if (stream->downSampleBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  stream->sampleRate = sampleRate;
+  stream->samplePeriod = 1.0 / sampleRate;
+  stream->numChannels = numChannels;
+  stream->oldRatePosition = 0;
+  stream->newRatePosition = 0;
+  stream->minPeriod = minPeriod;
+  stream->maxPeriod = maxPeriod;
+  stream->maxRequired = maxRequired;
+  stream->prevPeriod = 0;
+  return 1;
+}
+
+/* Create a sonic stream.  Return NULL only if we are out of memory and cannot
+   allocate the stream. */
+sonicStream sonicCreateStream(int sampleRate, int numChannels) {
+  sonicStream stream =
+      (sonicStream)sonicCalloc(1, sizeof(struct sonicStreamStruct));
+
+  sampleRate = CLAMP(sampleRate, SONIC_MIN_SAMPLE_RATE, SONIC_MAX_SAMPLE_RATE);
+  numChannels = CLAMP(numChannels, SONIC_MIN_CHANNELS, SONIC_MAX_CHANNELS);
+  if (stream == NULL) {
+    return NULL;
+  }
+  if (!allocateStreamBuffers(stream, sampleRate, numChannels)) {
+    return NULL;
+  }
+  stream->speed = 1.0f;
+  stream->pitch = 1.0f;
+  stream->volume = 1.0f;
+  stream->rate = 1.0f;
+  stream->oldRatePosition = 0;
+  stream->newRatePosition = 0;
+  stream->quality = 0;
+  return stream;
+}
+
+/* Get the sample rate of the stream. */
+int sonicGetSampleRate(sonicStream stream) { return stream->sampleRate; }
+
+/* Set the sample rate of the stream.  This will cause samples buffered in the
+   stream to be lost. */
+void sonicSetSampleRate(sonicStream stream, int sampleRate) {
+  sampleRate = CLAMP(sampleRate, SONIC_MIN_SAMPLE_RATE, SONIC_MAX_SAMPLE_RATE);
+  freeStreamBuffers(stream);
+  allocateStreamBuffers(stream, sampleRate, stream->numChannels);
+}
+
+/* Get the number of channels. */
+int sonicGetNumChannels(sonicStream stream) { return stream->numChannels; }
+
+/* Set the num channels of the stream.  This will cause samples buffered in the
+   stream to be lost. */
+void sonicSetNumChannels(sonicStream stream, int numChannels) {
+  numChannels = CLAMP(numChannels, SONIC_MIN_CHANNELS, SONIC_MAX_CHANNELS);
+  freeStreamBuffers(stream);
+  allocateStreamBuffers(stream, stream->sampleRate, numChannels);
+}
+
+/* Enlarge the output buffer if needed. */
+static int enlargeOutputBufferIfNeeded(sonicStream stream, int numSamples) {
+  int outputBufferSize = stream->outputBufferSize;
+
+  if (stream->numOutputSamples + numSamples > outputBufferSize) {
+    stream->outputBufferSize += (outputBufferSize >> 1) + numSamples;
+    stream->outputBuffer = (short*)sonicRealloc(
+        stream->outputBuffer, outputBufferSize, stream->outputBufferSize,
+        sizeof(short) * stream->numChannels);
+    if (stream->outputBuffer == NULL) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/* Enlarge the input buffer if needed. */
+static int enlargeInputBufferIfNeeded(sonicStream stream, int numSamples) {
+  int inputBufferSize = stream->inputBufferSize;
+
+  if (stream->numInputSamples + numSamples > inputBufferSize) {
+    stream->inputBufferSize += (inputBufferSize >> 1) + numSamples;
+    stream->inputBuffer = (short*)sonicRealloc(
+        stream->inputBuffer, inputBufferSize, stream->inputBufferSize,
+        sizeof(short) * stream->numChannels);
+    if (stream->inputBuffer == NULL) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/* Update stream->numInputSamples, and update stream->inputPlayTime.  Call this
+   whenever adding samples to the input buffer, to keep track of total expected
+   input play time accounting. */
+static void updateNumInputSamples(sonicStream stream, int numSamples) {
+  float speed = stream->speed / stream->pitch;
+
+  stream->numInputSamples += numSamples;
+  stream->inputPlayTime += numSamples * stream->samplePeriod / speed;
+}
+
+/* Add the input samples to the input buffer. */
+static int addFloatSamplesToInputBuffer(sonicStream stream,
+                                        const float* samples, int numSamples) {
+  short* buffer;
+  int count = numSamples * stream->numChannels;
+
+  if (numSamples == 0) {
+    return 1;
+  }
+  if (!enlargeInputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  buffer = stream->inputBuffer + stream->numInputSamples * stream->numChannels;
+  while (count--) {
+    *buffer++ = (*samples++) * 32767.0f;
+  }
+  updateNumInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Add the input samples to the input buffer. */
+static int addShortSamplesToInputBuffer(sonicStream stream,
+                                        const short* samples, int numSamples) {
+  if (numSamples == 0) {
+    return 1;
+  }
+  if (!enlargeInputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  memcpy(stream->inputBuffer + stream->numInputSamples * stream->numChannels,
+         samples, numSamples * sizeof(short) * stream->numChannels);
+  updateNumInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Add the input samples to the input buffer. */
+static int addUnsignedCharSamplesToInputBuffer(sonicStream stream,
+                                               const unsigned char* samples,
+                                               int numSamples) {
+  short* buffer;
+  int count = numSamples * stream->numChannels;
+
+  if (numSamples == 0) {
+    return 1;
+  }
+  if (!enlargeInputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  buffer = stream->inputBuffer + stream->numInputSamples * stream->numChannels;
+  while (count--) {
+    *buffer++ = (*samples++ - 128) << 8;
+  }
+  updateNumInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Remove input samples that we have already processed. */
+static void removeInputSamples(sonicStream stream, int position) {
+  int remainingSamples = stream->numInputSamples - position;
+
+  if (remainingSamples > 0) {
+    memmove(stream->inputBuffer,
+            stream->inputBuffer + position * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  /* If we play 3/4ths of the samples, then the expected play time of the
+     remaining samples is 1/4th of the original expected play time. */
+  stream->inputPlayTime =
+      (stream->inputPlayTime * remainingSamples) / stream->numInputSamples;
+  stream->numInputSamples = remainingSamples;
+}
+
+/* Copy from the input buffer to the output buffer, and remove the samples from
+   the input buffer. */
+static int copyInputToOutput(sonicStream stream, int numSamples) {
+  if (!enlargeOutputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  memcpy(stream->outputBuffer + stream->numOutputSamples * stream->numChannels,
+         stream->inputBuffer, numSamples * sizeof(short) * stream->numChannels);
+  stream->numOutputSamples += numSamples;
+  removeInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Copy from samples to the output buffer */
+static int copyToOutput(sonicStream stream, short* samples, int numSamples) {
+  if (!enlargeOutputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  memcpy(stream->outputBuffer + stream->numOutputSamples * stream->numChannels,
+         samples, numSamples * sizeof(short) * stream->numChannels);
+  stream->numOutputSamples += numSamples;
+  return 1;
+}
+
+/* Read data out of the stream.  Sometimes no data will be available, and zero
+   is returned, which is not an error condition. */
+int sonicReadFloatFromStream(sonicStream stream, float* samples,
+                             int maxSamples) {
+  int numSamples = stream->numOutputSamples;
+  int remainingSamples = 0;
+  short* buffer;
+  int count;
+
+  if (numSamples == 0) {
+    return 0;
+  }
+  if (numSamples > maxSamples) {
+    remainingSamples = numSamples - maxSamples;
+    numSamples = maxSamples;
+  }
+  buffer = stream->outputBuffer;
+  count = numSamples * stream->numChannels;
+  while (count--) {
+    *samples++ = (*buffer++) / 32767.0f;
+  }
+  if (remainingSamples > 0) {
+    memmove(stream->outputBuffer,
+            stream->outputBuffer + numSamples * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  stream->numOutputSamples = remainingSamples;
+  return numSamples;
+}
+
+/* Read short data out of the stream.  Sometimes no data will be available, and
+   zero is returned, which is not an error condition. */
+int sonicReadShortFromStream(sonicStream stream, short* samples,
+                             int maxSamples) {
+  int numSamples = stream->numOutputSamples;
+  int remainingSamples = 0;
+
+  if (numSamples == 0) {
+    return 0;
+  }
+  if (numSamples > maxSamples) {
+    remainingSamples = numSamples - maxSamples;
+    numSamples = maxSamples;
+  }
+  memcpy(samples, stream->outputBuffer,
+         numSamples * sizeof(short) * stream->numChannels);
+  if (remainingSamples > 0) {
+    memmove(stream->outputBuffer,
+            stream->outputBuffer + numSamples * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  stream->numOutputSamples = remainingSamples;
+  return numSamples;
+}
+
+/* Read unsigned char data out of the stream.  Sometimes no data will be
+   available, and zero is returned, which is not an error condition. */
+int sonicReadUnsignedCharFromStream(sonicStream stream, unsigned char* samples,
+                                    int maxSamples) {
+  int numSamples = stream->numOutputSamples;
+  int remainingSamples = 0;
+  short* buffer;
+  int count;
+
+  if (numSamples == 0) {
+    return 0;
+  }
+  if (numSamples > maxSamples) {
+    remainingSamples = numSamples - maxSamples;
+    numSamples = maxSamples;
+  }
+  buffer = stream->outputBuffer;
+  count = numSamples * stream->numChannels;
+  while (count--) {
+    *samples++ = (char)((*buffer++) >> 8) + 128;
+  }
+  if (remainingSamples > 0) {
+    memmove(stream->outputBuffer,
+            stream->outputBuffer + numSamples * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  stream->numOutputSamples = remainingSamples;
+  return numSamples;
+}
+
+/* Force the sonic stream to generate output using whatever data it currently
+   has.  No extra delay will be added to the output, but flushing in the middle
+   of words could introduce distortion. */
+int sonicFlushStream(sonicStream stream) {
+  int maxRequired = stream->maxRequired;
+  int remainingSamples = stream->numInputSamples;
+  float speed = stream->speed / stream->pitch;
+  float rate = stream->rate * stream->pitch;
+  int expectedOutputSamples =
+      stream->numOutputSamples +
+      (int)((remainingSamples / speed + stream->numPitchSamples) / rate + 0.5f);
+
+  /* Add enough silence to flush both input and pitch buffers. */
+  if (!enlargeInputBufferIfNeeded(stream, remainingSamples + 2 * maxRequired)) {
+    return 0;
+  }
+  memset(stream->inputBuffer + remainingSamples * stream->numChannels, 0,
+         2 * maxRequired * sizeof(short) * stream->numChannels);
+  stream->numInputSamples += 2 * maxRequired;
+  if (!sonicWriteShortToStream(stream, NULL, 0)) {
+    return 0;
+  }
+  /* Throw away any extra samples we generated due to the silence we added */
+  if (stream->numOutputSamples > expectedOutputSamples) {
+    stream->numOutputSamples = expectedOutputSamples;
+  }
+  /* Empty input and pitch buffers */
+  stream->numInputSamples = 0;
+  stream->inputPlayTime = 0.0f;
+  stream->timeError = 0.0f;
+  stream->numPitchSamples = 0;
+  return 1;
+}
+
+/* Return the number of samples in the output buffer */
+int sonicSamplesAvailable(sonicStream stream) {
+  return stream->numOutputSamples;
+}
+
+/* If skip is greater than one, average skip samples together and write them to
+   the down-sample buffer.  If numChannels is greater than one, mix the channels
+   together as we down sample. */
+static void downSampleInput(sonicStream stream, short* samples, int skip) {
+  int numSamples = stream->maxRequired / skip;
+  int samplesPerValue = stream->numChannels * skip;
+  int i, j;
+  int value;
+  short* downSamples = stream->downSampleBuffer;
+
+  for (i = 0; i < numSamples; i++) {
+    value = 0;
+    for (j = 0; j < samplesPerValue; j++) {
+      value += *samples++;
+    }
+    value /= samplesPerValue;
+    *downSamples++ = value;
+  }
+}
+
+/* Find the best frequency match in the range, and given a sample skip multiple.
+   For now, just find the pitch of the first channel. */
+static int findPitchPeriodInRange(short* samples, int minPeriod, int maxPeriod,
+                                  int* retMinDiff, int* retMaxDiff) {
+  int period, bestPeriod = 0, worstPeriod = 255;
+  short* s;
+  short* p;
+  short sVal, pVal;
+  unsigned long diff, minDiff = 1, maxDiff = 0;
+  int i;
+
+  for (period = minPeriod; period <= maxPeriod; period++) {
+    diff = 0;
+    s = samples;
+    p = samples + period;
+    for (i = 0; i < period; i++) {
+      sVal = *s++;
+      pVal = *p++;
+      diff += sVal >= pVal ? (unsigned short)(sVal - pVal)
+                           : (unsigned short)(pVal - sVal);
+    }
+    /* Note that the highest number of samples we add into diff will be less
+       than 256, since we skip samples.  Thus, diff is a 24 bit number, and
+       we can safely multiply by numSamples without overflow */
+    if (bestPeriod == 0 || diff * bestPeriod < minDiff * period) {
+      minDiff = diff;
+      bestPeriod = period;
+    }
+    if (diff * worstPeriod > maxDiff * period) {
+      maxDiff = diff;
+      worstPeriod = period;
+    }
+  }
+  *retMinDiff = minDiff / bestPeriod;
+  *retMaxDiff = maxDiff / worstPeriod;
+  return bestPeriod;
+}
+
+/* At abrupt ends of voiced words, we can have pitch periods that are better
+   approximated by the previous pitch period estimate.  Try to detect this case.
+ */
+static int prevPeriodBetter(sonicStream stream, int minDiff, int maxDiff,
+                            int preferNewPeriod) {
+  if (minDiff == 0 || stream->prevPeriod == 0) {
+    return 0;
+  }
+  if (preferNewPeriod) {
+    if (maxDiff > minDiff * 3) {
+      /* Got a reasonable match this period */
+      return 0;
+    }
+    if (minDiff * 2 <= stream->prevMinDiff * 3) {
+      /* Mismatch is not that much greater this period */
+      return 0;
+    }
+  } else {
+    if (minDiff <= stream->prevMinDiff) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/* Find the pitch period.  This is a critical step, and we may have to try
+   multiple ways to get a good answer.  This version uses Average Magnitude
+   Difference Function (AMDF).  To improve speed, we down sample by an integer
+   factor get in the 11KHz range, and then do it again with a narrower
+   frequency range without down sampling */
+static int findPitchPeriod(sonicStream stream, short* samples,
+                           int preferNewPeriod) {
+  int minPeriod = stream->minPeriod;
+  int maxPeriod = stream->maxPeriod;
+  int minDiff, maxDiff, retPeriod;
+  int skip = computeSkip(stream, stream->sampleRate);
+  int period;
+
+  if (stream->numChannels == 1 && skip == 1) {
+    period = findPitchPeriodInRange(samples, minPeriod, maxPeriod, &minDiff,
+                                    &maxDiff);
+  } else {
+    downSampleInput(stream, samples, skip);
+    period = findPitchPeriodInRange(stream->downSampleBuffer, minPeriod / skip,
+                                    maxPeriod / skip, &minDiff, &maxDiff);
+    if (skip != 1) {
+      period *= skip;
+      minPeriod = period - (skip << 2);
+      maxPeriod = period + (skip << 2);
+      if (minPeriod < stream->minPeriod) {
+        minPeriod = stream->minPeriod;
+      }
+      if (maxPeriod > stream->maxPeriod) {
+        maxPeriod = stream->maxPeriod;
+      }
+      if (stream->numChannels == 1) {
+        period = findPitchPeriodInRange(samples, minPeriod, maxPeriod, &minDiff,
+                                        &maxDiff);
+      } else {
+        downSampleInput(stream, samples, 1);
+        period = findPitchPeriodInRange(stream->downSampleBuffer, minPeriod,
+                                        maxPeriod, &minDiff, &maxDiff);
+      }
+    }
+  }
+  if (prevPeriodBetter(stream, minDiff, maxDiff, preferNewPeriod)) {
+    retPeriod = stream->prevPeriod;
+  } else {
+    retPeriod = period;
+  }
+  stream->prevMinDiff = minDiff;
+  stream->prevPeriod = period;
+  return retPeriod;
+}
+
+/* Overlap two sound segments, ramp the volume of one down, while ramping the
+   other one from zero up, and add them, storing the result at the output. */
+static void overlapAdd(int numSamples, int numChannels, short* out,
+                       short* rampDown, short* rampUp) {
+  short* o;
+  short* u;
+  short* d;
+  int i, t;
+
+  for (i = 0; i < numChannels; i++) {
+    o = out + i;
+    u = rampUp + i;
+    d = rampDown + i;
+    for (t = 0; t < numSamples; t++) {
+#ifdef SONIC_USE_SIN
+      float ratio = sin(t * M_PI / (2 * numSamples));
+      *o = *d * (1.0f - ratio) + *u * ratio;
+#else
+      *o = (*d * (numSamples - t) + *u * t) / numSamples;
+#endif
+      o += numChannels;
+      d += numChannels;
+      u += numChannels;
+    }
+  }
+}
+
+/* Just move the new samples in the output buffer to the pitch buffer */
+static int moveNewSamplesToPitchBuffer(sonicStream stream,
+                                       int originalNumOutputSamples) {
+  int numSamples = stream->numOutputSamples - originalNumOutputSamples;
+  int numChannels = stream->numChannels;
+  int pitchBufferSize = stream->pitchBufferSize;
+
+  if (stream->numPitchSamples + numSamples > pitchBufferSize) {
+    stream->pitchBufferSize += (pitchBufferSize >> 1) + numSamples;
+    stream->pitchBuffer = (short*)sonicRealloc(
+        stream->pitchBuffer, pitchBufferSize, stream->pitchBufferSize,
+        sizeof(short) * numChannels);
+  }
+  memcpy(stream->pitchBuffer + stream->numPitchSamples * numChannels,
+         stream->outputBuffer + originalNumOutputSamples * numChannels,
+         numSamples * sizeof(short) * numChannels);
+  stream->numOutputSamples = originalNumOutputSamples;
+  stream->numPitchSamples += numSamples;
+  return 1;
+}
+
+/* Remove processed samples from the pitch buffer. */
+static void removePitchSamples(sonicStream stream, int numSamples) {
+  int numChannels = stream->numChannels;
+  short* source = stream->pitchBuffer + numSamples * numChannels;
+
+  if (numSamples == 0) {
+    return;
+  }
+  if (numSamples != stream->numPitchSamples) {
+    memmove(
+        stream->pitchBuffer, source,
+        (stream->numPitchSamples - numSamples) * sizeof(short) * numChannels);
+  }
+  stream->numPitchSamples -= numSamples;
+}
+
+/* Approximate the sinc function times a Hann window from the sinc table. */
+static int findSincCoefficient(int i, int ratio, int width) {
+  int lobePoints = (SINC_TABLE_SIZE - 1) / SINC_FILTER_POINTS;
+  int left = i * lobePoints + (ratio * lobePoints) / width;
+  int right = left + 1;
+  int position = i * lobePoints * width + ratio * lobePoints - left * width;
+  int leftVal = sincTable[left];
+  int rightVal = sincTable[right];
+
+  return ((leftVal * (width - position) + rightVal * position) << 1) / width;
+}
+
+/* Return 1 if value >= 0, else -1.  This represents the sign of value. */
+static int getSign(int value) { return value >= 0 ? 1 : -1; }
+
+/* Interpolate the new output sample. */
+static short interpolate(sonicStream stream, short* in, int oldSampleRate,
+                         int newSampleRate) {
+  /* Compute N-point sinc FIR-filter here.  Clip rather than overflow. */
+  int i;
+  int total = 0;
+  int position = stream->newRatePosition * oldSampleRate;
+  int leftPosition = stream->oldRatePosition * newSampleRate;
+  int rightPosition = (stream->oldRatePosition + 1) * newSampleRate;
+  int ratio = rightPosition - position - 1;
+  int width = rightPosition - leftPosition;
+  int weight, value;
+  int oldSign;
+  int overflowCount = 0;
+
+  for (i = 0; i < SINC_FILTER_POINTS; i++) {
+    weight = findSincCoefficient(i, ratio, width);
+    value = in[i * stream->numChannels] * weight;
+    oldSign = getSign(total);
+    total += value;
+    if (oldSign != getSign(total) && getSign(value) == oldSign) {
+      /* We must have overflowed.  This can happen with a sinc filter. */
+      overflowCount += oldSign;
+    }
+  }
+  /* It is better to clip than to wrap if there was a overflow. */
+  if (overflowCount > 0) {
+    return SHRT_MAX;
+  } else if (overflowCount < 0) {
+    return SHRT_MIN;
+  }
+  return total >> 16;
+}
+
+/* Change the rate.  Interpolate with a sinc FIR filter using a Hann window. */
+static int adjustRate(sonicStream stream, float rate,
+                      int originalNumOutputSamples) {
+  int newSampleRate = stream->sampleRate / rate;
+  int oldSampleRate = stream->sampleRate;
+  int numChannels = stream->numChannels;
+  int position;
+  short *in, *out;
+  int i;
+  int N = SINC_FILTER_POINTS;
+
+  /* Set these values to help with the integer math */
+  while (newSampleRate > (1 << 14) || oldSampleRate > (1 << 14)) {
+    newSampleRate >>= 1;
+    oldSampleRate >>= 1;
+  }
+  if (stream->numOutputSamples == originalNumOutputSamples) {
+    return 1;
+  }
+  if (!moveNewSamplesToPitchBuffer(stream, originalNumOutputSamples)) {
+    return 0;
+  }
+  /* Leave at least N pitch sample in the buffer */
+  for (position = 0; position < stream->numPitchSamples - N; position++) {
+    while ((stream->oldRatePosition + 1) * newSampleRate >
+           stream->newRatePosition * oldSampleRate) {
+      if (!enlargeOutputBufferIfNeeded(stream, 1)) {
+        return 0;
+      }
+      out = stream->outputBuffer + stream->numOutputSamples * numChannels;
+      in = stream->pitchBuffer + position * numChannels;
+      for (i = 0; i < numChannels; i++) {
+        *out++ = interpolate(stream, in, oldSampleRate, newSampleRate);
+        in++;
+      }
+      stream->newRatePosition++;
+      stream->numOutputSamples++;
+    }
+    stream->oldRatePosition++;
+    if (stream->oldRatePosition == oldSampleRate) {
+      stream->oldRatePosition = 0;
+      stream->newRatePosition = 0;
+    }
+  }
+  removePitchSamples(stream, position);
+  return 1;
+}
+
+/* Skip over a pitch period.  Return the number of output samples. */
+static int skipPitchPeriod(sonicStream stream, short* samples, float speed,
+                           int period) {
+  long newSamples;
+  int numChannels = stream->numChannels;
+
+  if (speed >= 2.0f) {
+    /* For speeds >= 2.0, we skip over a portion of each pitch period rather
+       than dropping whole pitch periods. */
+    newSamples = period / (speed - 1.0f);
+  } else {
+    newSamples = period;
+  }
+  if (!enlargeOutputBufferIfNeeded(stream, newSamples)) {
+    return 0;
+  }
+  overlapAdd(newSamples, numChannels,
+             stream->outputBuffer + stream->numOutputSamples * numChannels,
+             samples, samples + period * numChannels);
+  stream->numOutputSamples += newSamples;
+  return newSamples;
+}
+
+/* Insert a pitch period, and determine how much input to copy directly. */
+static int insertPitchPeriod(sonicStream stream, short* samples, float speed,
+                             int period) {
+  long newSamples;
+  short* out;
+  int numChannels = stream->numChannels;
+
+  if (speed <= 0.5f) {
+    newSamples = period * speed / (1.0f - speed);
+  } else {
+    newSamples = period;
+  }
+  if (!enlargeOutputBufferIfNeeded(stream, period + newSamples)) {
+    return 0;
+  }
+  out = stream->outputBuffer + stream->numOutputSamples * numChannels;
+  memcpy(out, samples, period * sizeof(short) * numChannels);
+  out =
+      stream->outputBuffer + (stream->numOutputSamples + period) * numChannels;
+  overlapAdd(newSamples, numChannels, out, samples + period * numChannels,
+             samples);
+  stream->numOutputSamples += period + newSamples;
+  return newSamples;
+}
+
+/* PICOLA copies input to output until the total output samples == consumed
+   input samples * speed. */
+static int copyUnmodifiedSamples(sonicStream stream, short* samples,
+                                 float speed, int position, int* newSamples) {
+  int availableSamples = stream->numInputSamples - position;
+  float inputToCopyFloat =
+      1 - stream->timeError * speed / (stream->samplePeriod * (speed - 1.0));
+
+  *newSamples = inputToCopyFloat > availableSamples ? availableSamples
+                                                    : (int)inputToCopyFloat;
+  if (!copyToOutput(stream, samples, *newSamples)) {
+    return 0;
+  }
+  stream->timeError +=
+      *newSamples * stream->samplePeriod * (speed - 1.0) / speed;
+  return 1;
+}
+
+/* Resample as many pitch periods as we have buffered on the input.  Return 0 if
+   we fail to resize an input or output buffer. */
+static int changeSpeed(sonicStream stream, float speed) {
+  short* samples;
+  int numSamples = stream->numInputSamples;
+  int position = 0, period, newSamples;
+  int maxRequired = stream->maxRequired;
+
+  if (stream->numInputSamples < maxRequired) {
+    return 1;
+  }
+  do {
+    samples = stream->inputBuffer + position * stream->numChannels;
+    if ((speed > 1.0f && speed < 2.0f && stream->timeError < 0.0f) ||
+        (speed < 1.0f && speed > 0.5f && stream->timeError > 0.0f)) {
+      /* Deal with the case where PICOLA is still copying input samples to
+         output unmodified, */
+      if (!copyUnmodifiedSamples(stream, samples, speed, position,
+                                 &newSamples)) {
+        return 0;
+      }
+      position += newSamples;
+    } else {
+      /* We are in the remaining cases, either inserting/removing a pitch period
+         for speed < 2.0X, or a portion of one for speed >= 2.0X. */
+      period = findPitchPeriod(stream, samples, 1);
+#ifdef SONIC_SPECTROGRAM
+      if (stream->spectrogram != NULL) {
+        sonicAddPitchPeriodToSpectrogram(stream->spectrogram, samples, period,
+                                         stream->numChannels);
+        newSamples = period;
+        position += period;
+      } else
+#endif /* SONIC_SPECTROGRAM */
+        if (speed > 1.0) {
+          newSamples = skipPitchPeriod(stream, samples, speed, period);
+          position += period + newSamples;
+          if (speed < 2.0) {
+            stream->timeError += newSamples * stream->samplePeriod -
+                                 (period + newSamples) * stream->inputPlayTime /
+                                     stream->numInputSamples;
+          }
+        } else {
+          newSamples = insertPitchPeriod(stream, samples, speed, period);
+          position += newSamples;
+          if (speed > 0.5) {
+            stream->timeError +=
+                (period + newSamples) * stream->samplePeriod -
+                newSamples * stream->inputPlayTime / stream->numInputSamples;
+          }
+        }
+      if (newSamples == 0) {
+        return 0; /* Failed to resize output buffer */
+      }
+    }
+  } while (position + maxRequired <= numSamples);
+  removeInputSamples(stream, position);
+  return 1;
+}
+
+/* Resample as many pitch periods as we have buffered on the input.  Return 0 if
+   we fail to resize an input or output buffer.  Also scale the output by the
+   volume. */
+static int processStreamInput(sonicStream stream) {
+  int originalNumOutputSamples = stream->numOutputSamples;
+  float rate = stream->rate * stream->pitch;
+  float localSpeed;
+
+  if (stream->numInputSamples == 0) {
+    return 1;
+  }
+  localSpeed =
+      stream->numInputSamples * stream->samplePeriod / stream->inputPlayTime;
+  if (localSpeed > 1.00001 || localSpeed < 0.99999) {
+    changeSpeed(stream, localSpeed);
+  } else {
+    if (!copyInputToOutput(stream, stream->numInputSamples)) {
+      return 0;
+    }
+  }
+  if (rate != 1.0f) {
+    if (!adjustRate(stream, rate, originalNumOutputSamples)) {
+      return 0;
+    }
+  }
+  if (stream->volume != 1.0f) {
+    /* Adjust output volume. */
+    scaleSamples(
+        stream->outputBuffer + originalNumOutputSamples * stream->numChannels,
+        (stream->numOutputSamples - originalNumOutputSamples) *
+            stream->numChannels,
+        stream->volume);
+  }
+  return 1;
+}
+
+/* Write floating point data to the input buffer and process it. */
+int sonicWriteFloatToStream(sonicStream stream, const float* samples,
+                            int numSamples) {
+  if (!addFloatSamplesToInputBuffer(stream, samples, numSamples)) {
+    return 0;
+  }
+  return processStreamInput(stream);
+}
+
+/* Simple wrapper around sonicWriteFloatToStream that does the short to float
+   conversion for you. */
+int sonicWriteShortToStream(sonicStream stream, const short* samples,
+                            int numSamples) {
+  if (!addShortSamplesToInputBuffer(stream, samples, numSamples)) {
+    return 0;
+  }
+  return processStreamInput(stream);
+}
+
+/* Simple wrapper around sonicWriteFloatToStream that does the unsigned char to
+   float conversion for you. */
+int sonicWriteUnsignedCharToStream(sonicStream stream,
+                                   const unsigned char* samples,
+                                   int numSamples) {
+  if (!addUnsignedCharSamplesToInputBuffer(stream, samples, numSamples)) {
+    return 0;
+  }
+  return processStreamInput(stream);
+}
+
+/* This is a non-stream oriented interface to just change the speed of a sound
+ * sample */
+int sonicChangeFloatSpeed(float* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels) {
+  sonicStream stream = sonicCreateStream(sampleRate, numChannels);
+
+  sonicSetSpeed(stream, speed);
+  sonicSetPitch(stream, pitch);
+  sonicSetRate(stream, rate);
+  sonicSetVolume(stream, volume);
+  sonicWriteFloatToStream(stream, samples, numSamples);
+  sonicFlushStream(stream);
+  numSamples = sonicSamplesAvailable(stream);
+  sonicReadFloatFromStream(stream, samples, numSamples);
+  sonicDestroyStream(stream);
+  return numSamples;
+}
+
+/* This is a non-stream oriented interface to just change the speed of a sound
+ * sample */
+int sonicChangeShortSpeed(short* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels) {
+  sonicStream stream = sonicCreateStream(sampleRate, numChannels);
+
+  sonicSetSpeed(stream, speed);
+  sonicSetPitch(stream, pitch);
+  sonicSetRate(stream, rate);
+  sonicSetVolume(stream, volume);
+  sonicWriteShortToStream(stream, samples, numSamples);
+  sonicFlushStream(stream);
+  numSamples = sonicSamplesAvailable(stream);
+  sonicReadShortFromStream(stream, samples, numSamples);
+  sonicDestroyStream(stream);
+  return numSamples;
+}

--- a/third_party/sonic/sonic.h
+++ b/third_party/sonic/sonic.h
@@ -1,0 +1,304 @@
+#ifndef SONIC_H_
+#define SONIC_H_
+
+/* Sonic library
+   Copyright 2010
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+/*
+The Sonic Library implements a new algorithm invented by Bill Cox for the
+specific purpose of speeding up speech by high factors at high quality.  It
+generates smooth speech at speed up factors as high as 6X, possibly more.  It is
+also capable of slowing down speech, and generates high quality results
+regardless of the speed up or slow down factor.  For speeding up speech by 2X or
+more, the following equation is used:
+
+    newSamples = period/(speed - 1.0)
+    scale = 1.0/newSamples;
+
+where period is the current pitch period, determined using AMDF or any other
+pitch estimator, and speed is the speedup factor.  If the current position in
+the input stream is pointed to by "samples", and the current output stream
+position is pointed to by "out", then newSamples number of samples can be
+generated with:
+
+    out[t] = (samples[t]*(newSamples - t) + samples[t + period]*t)/newSamples;
+
+where t = 0 to newSamples - 1.
+
+For speed factors < 2X, the PICOLA algorithm is used.  The above
+algorithm is first used to double the speed of one pitch period.  Then, enough
+input is directly copied from the input to the output to achieve the desired
+speed up factor, where 1.0 < speed < 2.0.  The amount of data copied is derived:
+
+    speed = (2*period + length)/(period + length)
+    speed*length + speed*period = 2*period + length
+    length(speed - 1) = 2*period - speed*period
+    length = period*(2 - speed)/(speed - 1)
+
+For slowing down speech where 0.5 < speed < 1.0, a pitch period is inserted into
+the output twice, and length of input is copied from the input to the output
+until the output desired speed is reached.  The length of data copied is:
+
+    length = period*(speed - 0.5)/(1 - speed)
+
+For slow down factors below 0.5, no data is copied, and an algorithm
+similar to high speed factors is used.
+*/
+
+/* Uncomment this to use sin-wav based overlap add which in theory can improve
+   sound quality slightly, at the expense of lots of floating point math. */
+/* #define SONIC_USE_SIN */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef SONIC_INTERNAL
+/* The following #define's are used to change the names of the routines defined
+ * here so that a new library (i.e. speedy) can reuse these names, and then call
+ * the original names.  We do this for two reasons: 1) we don't want to change
+ * the original API, and 2) we want to add a shim, using the original names and
+ * still call these routines.
+ *
+ * Original users of this API and the libsonic library need to do nothing.  The
+ * original behavior remains.
+ *
+ * A new user that add some additional functionality above this library (a shim)
+ * should #define SONIC_INTERNAL before including this file, undefine all these
+ * symbols and call the sonicIntXXX functions directly.
+ */
+#define sonicCreateStream sonicIntCreateStream
+#define sonicDestroyStream sonicIntDestroyStream
+#define sonicWriteFloatToStream sonicIntWriteFloatToStream
+#define sonicWriteShortToStream sonicIntWriteShortToStream
+#define sonicWriteUnsignedCharToStream sonicIntWriteUnsignedCharToStream
+#define sonicReadFloatFromStream sonicIntReadFloatFromStream
+#define sonicReadShortFromStream sonicIntReadShortFromStream
+#define sonicReadUnsignedCharFromStream sonicIntReadUnsignedCharFromStream
+#define sonicFlushStream sonicIntFlushStream
+#define sonicSamplesAvailable sonicIntSamplesAvailable
+#define sonicGetSpeed sonicIntGetSpeed
+#define sonicSetSpeed sonicIntSetSpeed
+#define sonicGetPitch sonicIntGetPitch
+#define sonicSetPitch sonicIntSetPitch
+#define sonicGetRate sonicIntGetRate
+#define sonicSetRate sonicIntSetRate
+#define sonicGetVolume sonicIntGetVolume
+#define sonicSetVolume sonicIntSetVolume
+#define sonicGetQuality sonicIntGetQuality
+#define sonicSetQuality sonicIntSetQuality
+#define sonicGetSampleRate sonicIntGetSampleRate
+#define sonicSetSampleRate sonicIntSetSampleRate
+#define sonicGetNumChannels sonicIntGetNumChannels
+#define sonicGetUserData sonicIntGetUserData
+#define sonicSetUserData sonicIntSetUserData
+#define sonicSetNumChannels sonicIntSetNumChannels
+#define sonicChangeFloatSpeed sonicIntChangeFloatSpeed
+#define sonicChangeShortSpeed sonicIntChangeShortSpeed
+#define sonicEnableNonlinearSpeedup sonicIntEnableNonlinearSpeedup
+#define sonicSetDurationFeedbackStrength sonicIntSetDurationFeedbackStrength
+#define sonicComputeSpectrogram sonicIntComputeSpectrogram
+#define sonicGetSpectrogram sonicIntGetSpectrogram
+
+#endif /* SONIC_INTERNAL */
+
+/* This specifies the range of voice pitches we try to match.
+   Note that if we go lower than 65, we could overflow in findPitchInRange */
+#ifndef SONIC_MIN_PITCH
+#define SONIC_MIN_PITCH 65
+#endif  /* SONIC_MIN_PITCH */
+#ifndef SONIC_MAX_PITCH
+#define SONIC_MAX_PITCH 400
+#endif  /* SONIC_MAX_PITCH */
+
+/* The following values are used to clamp inputs such as speed to sane values.
+ */
+#define SONIC_MIN_VOLUME 0.01f
+#define SONIC_MAX_VOLUME 100.0f
+#define SONIC_MIN_SPEED 0.05f
+#define SONIC_MAX_SPEED 20.0f
+#define SONIC_MIN_PITCH_SETTING 0.05f
+#define SONIC_MAX_PITCH_SETTING 20.0f
+#define SONIC_MIN_RATE 0.05f
+#define SONIC_MAX_RATE 20.0f
+#define SONIC_MIN_SAMPLE_RATE 1000
+#define SONIC_MAX_SAMPLE_RATE 500000
+#define SONIC_MIN_CHANNELS 1
+#define SONIC_MAX_CHANNELS 32
+
+/* These are used to down-sample some inputs to improve speed */
+#define SONIC_AMDF_FREQ 4000
+
+struct sonicStreamStruct;
+typedef struct sonicStreamStruct* sonicStream;
+
+/* For all of the following functions, numChannels is multiplied by numSamples
+   to determine the actual number of values read or returned. */
+
+/* Create a sonic stream.  Return NULL only if we are out of memory and cannot
+  allocate the stream. Set numChannels to 1 for mono, and 2 for stereo. */
+sonicStream sonicCreateStream(int sampleRate, int numChannels);
+/* Destroy the sonic stream. */
+void sonicDestroyStream(sonicStream stream);
+/* Attach user data to the stream. */
+void sonicSetUserData(sonicStream stream, void *userData);
+/* Retrieve user data attached to the stream. */
+void *sonicGetUserData(sonicStream stream);
+/* Use this to write floating point data to be speed up or down into the stream.
+   Values must be between -1 and 1.  Return 0 if memory realloc failed,
+   otherwise 1 */
+int sonicWriteFloatToStream(sonicStream stream, const float* samples, int numSamples);
+/* Use this to write 16-bit data to be speed up or down into the stream.
+   Return 0 if memory realloc failed, otherwise 1 */
+int sonicWriteShortToStream(sonicStream stream, const short* samples, int numSamples);
+/* Use this to write 8-bit unsigned data to be speed up or down into the stream.
+   Return 0 if memory realloc failed, otherwise 1 */
+int sonicWriteUnsignedCharToStream(sonicStream stream, const unsigned char* samples,
+                                   int numSamples);
+/* Use this to read floating point data out of the stream.  Sometimes no data
+   will be available, and zero is returned, which is not an error condition. */
+int sonicReadFloatFromStream(sonicStream stream, float* samples,
+                             int maxSamples);
+/* Use this to read 16-bit data out of the stream.  Sometimes no data will
+   be available, and zero is returned, which is not an error condition. */
+int sonicReadShortFromStream(sonicStream stream, short* samples,
+                             int maxSamples);
+/* Use this to read 8-bit unsigned data out of the stream.  Sometimes no data
+   will be available, and zero is returned, which is not an error condition. */
+int sonicReadUnsignedCharFromStream(sonicStream stream, unsigned char* samples,
+                                    int maxSamples);
+/* Force the sonic stream to generate output using whatever data it currently
+   has.  No extra delay will be added to the output, but flushing in the middle
+   of words could introduce distortion. */
+int sonicFlushStream(sonicStream stream);
+/* Return the number of samples in the output buffer */
+int sonicSamplesAvailable(sonicStream stream);
+/* Get the speed of the stream. */
+float sonicGetSpeed(sonicStream stream);
+/* Set the speed of the stream. */
+void sonicSetSpeed(sonicStream stream, float speed);
+/* Get the pitch of the stream. */
+float sonicGetPitch(sonicStream stream);
+/* Set the pitch of the stream. */
+void sonicSetPitch(sonicStream stream, float pitch);
+/* Get the rate of the stream. */
+float sonicGetRate(sonicStream stream);
+/* Set the rate of the stream. */
+void sonicSetRate(sonicStream stream, float rate);
+/* Get the scaling factor of the stream. */
+float sonicGetVolume(sonicStream stream);
+/* Set the scaling factor of the stream. */
+void sonicSetVolume(sonicStream stream, float volume);
+/* Chord pitch is DEPRECATED.  AFAIK, it was never used by anyone.  These
+   functions still exist to avoid breaking existing code. */
+/* Get the chord pitch setting. */
+int sonicGetChordPitch(sonicStream stream);
+/* Set chord pitch mode on or off.  Default is off.  See the documentation
+   page for a description of this feature. */
+void sonicSetChordPitch(sonicStream stream, int useChordPitch);
+/* Get the quality setting. */
+int sonicGetQuality(sonicStream stream);
+/* Set the "quality".  Default 0 is virtually as good as 1, but very much
+ * faster. */
+void sonicSetQuality(sonicStream stream, int quality);
+/* Get the sample rate of the stream. */
+int sonicGetSampleRate(sonicStream stream);
+/* Set the sample rate of the stream.  This will drop any samples that have not
+ * been read. */
+void sonicSetSampleRate(sonicStream stream, int sampleRate);
+/* Get the number of channels. */
+int sonicGetNumChannels(sonicStream stream);
+/* Set the number of channels.  This will drop any samples that have not been
+ * read. */
+void sonicSetNumChannels(sonicStream stream, int numChannels);
+/* This is a non-stream oriented interface to just change the speed of a sound
+   sample.  It works in-place on the sample array, so there must be at least
+   speed*numSamples available space in the array. Returns the new number of
+   samples. */
+int sonicChangeFloatSpeed(float* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels);
+/* This is a non-stream oriented interface to just change the speed of a sound
+   sample.  It works in-place on the sample array, so there must be at least
+   speed*numSamples available space in the array. Returns the new number of
+   samples. */
+int sonicChangeShortSpeed(short* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels);
+
+#ifdef SONIC_SPECTROGRAM
+/*
+This code generates high quality spectrograms from sound samples, using
+Time-Aliased-FFTs as described at:
+
+    https://github.com/waywardgeek/spectrogram
+
+Basically, two adjacent pitch periods are overlap-added to create a sound
+sample that accurately represents the speech sound at that moment in time.
+This set of samples is converted to a spetral line using an FFT, and the result
+is saved as a single spectral line at that moment in time.  The resulting
+spectral lines vary in resolution (it is equal to the number of samples in the
+pitch period), and the spacing of spectral lines also varies (proportional to
+the numver of samples in the pitch period).
+
+To generate a bitmap, linear interpolation is used to render the grayscale
+value at any particular point in time and frequency.
+*/
+
+#define SONIC_MAX_SPECTRUM_FREQ 5000
+
+struct sonicSpectrogramStruct;
+struct sonicBitmapStruct;
+typedef struct sonicSpectrogramStruct* sonicSpectrogram;
+typedef struct sonicBitmapStruct* sonicBitmap;
+
+/* sonicBitmap objects represent spectrograms as grayscale bitmaps where each
+   pixel is from 0 (black) to 255 (white).  Bitmaps are rows*cols in size.
+   Rows are indexed top to bottom and columns are indexed left to right */
+struct sonicBitmapStruct {
+  unsigned char* data;
+  int numRows;
+  int numCols;
+};
+
+/* Enable coomputation of a spectrogram on the fly. */
+void sonicComputeSpectrogram(sonicStream stream);
+
+/* Get the spectrogram. */
+sonicSpectrogram sonicGetSpectrogram(sonicStream stream);
+
+/* Create an empty spectrogram. Called automatically if sonicComputeSpectrogram
+   has been called. */
+sonicSpectrogram sonicCreateSpectrogram(int sampleRate);
+
+/* Destroy the spectrotram.  This is called automatically when calling
+   sonicDestroyStream. */
+void sonicDestroySpectrogram(sonicSpectrogram spectrogram);
+
+/* Convert the spectrogram to a bitmap. Caller must destroy bitmap when done. */
+sonicBitmap sonicConvertSpectrogramToBitmap(sonicSpectrogram spectrogram,
+                                            int numRows, int numCols);
+
+/* Destroy a bitmap returned by sonicConvertSpectrogramToBitmap. */
+void sonicDestroyBitmap(sonicBitmap bitmap);
+
+int sonicWritePGM(sonicBitmap bitmap, char* fileName);
+
+/* Add two pitch periods worth of samples to the spectrogram.  There must be
+   2*period samples.  Time should advance one pitch period for each call to
+   this function. */
+void sonicAddPitchPeriodToSpectrogram(sonicSpectrogram spectrogram,
+                                      short* samples, int numSamples,
+                                      int numChannels);
+#endif  /* SONIC_SPECTROGRAM */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* SONIC_H_ */

--- a/third_party/sonic/sonic_wrapper.c
+++ b/third_party/sonic/sonic_wrapper.c
@@ -1,0 +1,37 @@
+#include "sonic.h"
+
+#if defined(_WIN32)
+#define KCTTS_EXPORT __declspec(dllexport)
+#else
+#define KCTTS_EXPORT __attribute__((visibility("default")))
+#endif
+
+KCTTS_EXPORT sonicStream kctts_sonic_create(int sample_rate, int channels) {
+  return sonicCreateStream(sample_rate, channels);
+}
+
+KCTTS_EXPORT void kctts_sonic_destroy(sonicStream stream) {
+  sonicDestroyStream(stream);
+}
+
+KCTTS_EXPORT void kctts_sonic_set_speed(sonicStream stream, float speed) {
+  sonicSetSpeed(stream, speed);
+}
+
+KCTTS_EXPORT int kctts_sonic_write_float(
+    sonicStream stream, const float* samples, int frame_count) {
+  return sonicWriteFloatToStream(stream, samples, frame_count);
+}
+
+KCTTS_EXPORT int kctts_sonic_read_float(
+    sonicStream stream, float* samples, int max_frames) {
+  return sonicReadFloatFromStream(stream, samples, max_frames);
+}
+
+KCTTS_EXPORT int kctts_sonic_flush(sonicStream stream) {
+  return sonicFlushStream(stream);
+}
+
+KCTTS_EXPORT int kctts_sonic_available(sonicStream stream) {
+  return sonicSamplesAvailable(stream);
+}


### PR DESCRIPTION
## Summary

- make pause, resume, and pitch-preserved speed changes apply to active speech
- preserve clipboard structure and normalize headings, shorthand, and code for more natural reading
- start Kokoro earlier, remove fixed latency, and show honest first-audio progress
- add request-scoped lifecycle events, cancellation, playback offsets, and bounded queue tests
- vendor and package the Apache-2.0 Sonic streaming speech-rate processor
- fix the floating widget close race and enable its native macOS shadow
- add v0.7.0 versioning, roadmap, benchmark tooling, release documentation, and cross-platform PR CI

## Why

The previous playback controls acted on coarse generated chunks, flattened useful document structure, and could not alter speed during active speech. Reader Engine separates text planning, inference, and playback so the app feels immediate and controllable while remaining fully local.

## Validation

- 50 frontend tests
- frontend production build
- 24 sidecar tests
- 13 tooling tests
- 2 Rust tests plus doc tests
- native Sonic duration, pitch, streaming response, and range tests
- source-sidecar startup and health smoke test
- signed frozen Apple Silicon sidecar startup and health smoke test
- manual Apple Silicon validation of live speed changes and pause/resume
- GitHub workflow YAML validation

## Release scope

Pocket TTS and experimental GPU selection are intentionally deferred. The new PR CI validates Windows x64, macOS Apple Silicon, and macOS Intel before the v0.7.0 tag is published.