### PR TITLE
fix: restore Intel macOS release compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,28 @@ jobs:
           pip install -r requirements.txt
           python -m spacy download en_core_web_sm
 
+      - name: Verify speech dependency compatibility
+        shell: bash
+        run: |
+          python - <<'PY'
+          from importlib.metadata import version
+
+          import numpy
+          import torch
+          from transformers import AlbertConfig, AlbertModel, is_torch_available
+
+          assert numpy.__version__ == "1.26.4", numpy.__version__
+          assert version("transformers") == "4.57.6", version("transformers")
+          assert is_torch_available(), f"Transformers disabled PyTorch {torch.__version__}"
+          AlbertModel(AlbertConfig())
+          print(
+              "Speech dependencies compatible:",
+              f"numpy={numpy.__version__}",
+              f"torch={torch.__version__}",
+              f"transformers={version('transformers')}",
+          )
+          PY
+
       - name: Build Sidecar with PyInstaller
         shell: bash
         run: |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kokoro Clipboard TTS v0.7 Roadmap
 
-Status: v0.7.0 release candidate
+Status: v0.7.1 packaging hotfix release candidate
 Baseline release: v0.6.3
 Working release name: **Reader Engine**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
 flask
 sounddevice
 soundfile
-numpy
+# PyTorch 2.2.2 is the newest wheel available for Intel macOS. NumPy 2.x is
+# ABI-incompatible with that build, so keep the last NumPy 1.x release.
+numpy==1.26.4
 kokoro>=0.9.4
 torch
 loguru
-transformers
+# Transformers 5 requires PyTorch >=2.4 and disables the Intel macOS wheel.
+# Kokoro 0.9.4 uses the stable Transformers 4 Albert API.
+transformers==4.57.6
 onnxruntime
 misaki[en]>=0.9.4
 phonemizer-fork==3.3.2

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arboard",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.7.0"
+version = "0.7.1"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- pin NumPy 1.26.4 for the PyTorch 2.2.2 Intel macOS ABI
- pin Transformers 4.57.6 so Kokoro remains compatible with the newest Intel Mac PyTorch wheel
- assert the speech dependency combination before expensive packaging
- bump the corrected hotfix package to v0.7.1

## Why

The v0.7.0 release pipeline exposed dependency drift on `macos-15-intel`: Transformers 5 disabled PyTorch 2.2.2, and NumPy 2.x was ABI-incompatible with that wheel. Apple Silicon completed successfully; this hotfix makes all release targets deterministic.

## Validation

- 24 sidecar tests
- 13 tooling tests
- 50 frontend tests
- production frontend build
- Rust unit and doc tests
- local import/model construction with NumPy 1.26.4, Transformers 4.57.6, and PyTorch
- release workflow YAML parse and diff checks