### PR TITLE
release: Speech Intelligence v0.8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,17 +221,29 @@ jobs:
         working-directory: src-tauri
         run: cargo test
 
+      - name: Verify updater signing configuration
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          test -n "$TAURI_SIGNING_PRIVATE_KEY"
+          test -n "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Kokoro Clipboard TTS ${{ github.ref_name }}"
           releaseBody: "See the assets below to download and install."
           releaseDraft: false
           prerelease: false
-          uploadUpdaterJson: false
-          uploadUpdaterSignatures: false
+          uploadUpdaterJson: true
+          uploadUpdaterSignatures: true
+          updaterJsonPreferNsis: true
           releaseAssetNamePattern: "[name]_[version]_[platform]_[arch][setup].[ext]"
           args: ${{ startsWith(matrix.platform, 'macos-') && format('--target {0}', matrix.target) || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,20 +151,14 @@ jobs:
             "${CODESIGN_ARGS[@]}" \
             --add-data "sidecar/model${SEP}model" \
             --add-binary "${SONIC_LIBRARY}${SEP}native" \
-            --collect-all onnxruntime \
             --collect-all kokoro \
             --collect-all misaki \
             --collect-all phonemizer \
             --collect-all language_tags \
             --collect-all espeakng_loader \
-            --collect-all huggingface_hub \
-            --collect-all sounddevice \
-            --collect-all soundfile \
-            --collect-all torch \
-            --collect-all loguru \
-            --collect-all transformers \
-            --collect-all spacy \
             --collect-all en_core_web_sm \
+            --exclude-module onnxruntime \
+            --exclude-module spacy.tests \
             sidecar/kokoro_server.py
           mkdir -p src-tauri/binaries
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.8.0 — 2026-07-27
+
+### Highlights
+
+- Replay the sentence currently being heard, then continue forward; use Option+Left on macOS or Alt+Left on Windows.
+- Preview the selected voice and volume directly in Settings.
+- Read common chat shorthand, technical initialisms, dates, times, money, percentages, versions, links, email addresses, paths, and inline code more deliberately.
+- Preserve a useful pause when a copied line break separates complete thoughts.
+- Keep Kokoro inference deterministic by explicitly running the model in evaluation mode.
+- Show the app version, cold-start milestones, and better first-audio wait feedback.
+- Restore customized global shortcuts correctly after an app restart.
+- Bootstrap signed in-app updates with download, install, and restart progress.
+
+### Packaging decision
+
+The default remains the compact, fully offline Kokoro package (approximately 500 MB on Apple Silicon). A pre-extracted runtime approached 1 GB installed and was rejected despite faster repeat launches. Unused ONNX and test modules were removed without changing the model or speech quality.
+
+### Update note
+
+v0.7.1 cannot authenticate an in-app update because it predates the signed release channel. Install v0.8.0 manually from GitHub Releases once; v0.8.1 will be the first end-to-end updater verification release.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ Reads your clipboard aloud with [**Kokoro-82M**](https://github.com/hexgrad/koko
 | Feature | Description |
 |---|---|
 | **Global Hotkey** | Select text anywhere → press `Win+Shift+Q` on Windows or `Control+Option+R` on macOS → hear it read aloud |
-| **Floating Reader** | A minimal, always-on-top widget appears near your cursor with Play/Pause, Stop, and Speed controls |
-| **Speed Control** | Click or scroll-wheel to cycle: 0.5× → 0.75× → 1× → 1.25× → 1.5× → 1.75× → 2× |
+| **Floating Reader** | A minimal, always-on-top widget appears near your cursor with Play/Pause, Stop, replay-current-sentence, and Speed controls |
+| **Live Speed Control** | Click or scroll to adjust active speech from 0.5×–2.0× without changing pitch; 0.75×–1.5× is the quality-first range |
+| **Speech-Aware Reading** | Preserves headings, paragraphs, lists, and useful line breaks; handles common shorthand, dates, money, links, paths, and code intentionally |
 | **28 Voice Presets** | Choose from Kokoro's full voice library (default: Fenrir) |
+| **Voice Preview** | Audition the selected voice and volume directly in Settings before saving |
 | **System Tray** | Runs headless — choose **Read Clipboard** from the tray/menu-bar menu as an alternative to the hotkey |
-| **Auto-Updater** | Silently checks for updates on launch and offers one-click install |
-| **100% Local** | No cloud APIs. No data leaves your machine. Zero latency. |
+| **Auto-Updater** | Checks the signed release channel and offers download, install, and restart controls in Settings |
+| **100% Local** | No cloud APIs, accounts, or telemetry. Clipboard text and speech stay on your machine |
 
 ---
 
@@ -82,8 +84,8 @@ Kokoro-Clipboard-TTS/
 │   │   ├── SettingsWindow.tsx       # Voice & shortcut config
 │   │   └── Tutorial.tsx             # First-run guide
 │   └── utils/
-│       ├── textCleaner.ts           # Markdown stripper for TTS
-│       └── textCleaner.test.ts      # Vitest suite
+│       ├── speechPlanner.ts         # Structure-aware speech planning
+│       └── speechPlanner.test.ts    # Planner regression suite
 ├── src-tauri/
 │   ├── tauri.conf.json              # Tauri config
 │   ├── Cargo.toml                   # Rust dependencies

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Please check out our **[Contributing Guide](.agent/CONTRIBUTING.md)** for full d
 
 *The React frontend communicates via Tauri with the Rust backend, which securely manages a headless local Python server running the Kokoro TTS engine.*
 
-The Python sidecar is packaged as a standalone executable during release builds, so users do not need to install Python or set up the AI stack manually. It bundles the Kokoro runtime and its supporting libraries, including `torch`, `onnxruntime`, `phonemizer`, `espeak-ng` data, and the model weights/voices used for offline synthesis. That keeps the app fully local while still shipping the native ML dependencies needed to generate speech.
+The Python sidecar is packaged as a standalone executable during release builds, so users do not need to install Python or set up the AI stack manually. It bundles the Kokoro runtime and its supporting libraries, including `torch`, `phonemizer`, `espeak-ng` data, and the model weights/voices used for offline synthesis. That keeps the app fully local while still shipping the native ML dependencies needed to generate speech.
 
 ---
 

--- a/RELEASE_TESTING.md
+++ b/RELEASE_TESTING.md
@@ -55,20 +55,14 @@ python scripts/build_sonic_dsp.py
 pyinstaller --onefile --name kokoro `
   --add-data "sidecar/model;model" `
   --add-binary "sidecar/native/sonic_kctts.dll;native" `
-  --collect-all onnxruntime `
   --collect-all kokoro `
   --collect-all misaki `
   --collect-all phonemizer `
   --collect-all language_tags `
   --collect-all espeakng_loader `
-  --collect-all huggingface_hub `
-  --collect-all sounddevice `
-  --collect-all soundfile `
-  --collect-all torch `
-  --collect-all loguru `
-  --collect-all transformers `
-  --collect-all spacy `
   --collect-all en_core_web_sm `
+  --exclude-module onnxruntime `
+  --exclude-module spacy.tests `
   sidecar/kokoro_server.py
 ```
 
@@ -77,20 +71,14 @@ pyinstaller --onefile --name kokoro `
 pyinstaller --onefile --name kokoro \
   --add-data "sidecar/model;model" \
   --add-binary "sidecar/native/sonic_kctts.dll;native" \
-  --collect-all onnxruntime \
   --collect-all kokoro \
   --collect-all misaki \
   --collect-all phonemizer \
   --collect-all language_tags \
   --collect-all espeakng_loader \
-  --collect-all huggingface_hub \
-  --collect-all sounddevice \
-  --collect-all soundfile \
-  --collect-all torch \
-  --collect-all loguru \
-  --collect-all transformers \
-  --collect-all spacy \
   --collect-all en_core_web_sm \
+  --exclude-module onnxruntime \
+  --exclude-module spacy.tests \
   sidecar/kokoro_server.py
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,15 @@
-# Kokoro Clipboard TTS v0.7 Roadmap
+# Kokoro Clipboard TTS v0.8 Roadmap
 
-Status: v0.7.1 packaging hotfix release candidate
-Baseline release: v0.6.3
-Working release name: **Reader Engine**
+Status: v0.8.0 release candidate
+Baseline release: v0.7.1
+Working release name: **Speech Intelligence**
 
 ## Release train
 
-- **v0.7.0 — Reader Engine:** ship the locally validated session controller, exact pause/resume, live pitch-preserved speed, structural clipboard/planner foundation, code-block setting, startup prewarm, and first-audio feedback. Pocket TTS and GPU selection are not included.
-- **v0.8.x — Speech Intelligence:** numbers, dates, URLs, paths, pronunciation dictionary, pause tuning, sentence navigation, and reader profiles.
-- **v0.9.x — Engine Lab:** optional Pocket TTS engine packs, evidence-based GPU/backend selection, package slimming, and broader platform bake-offs.
-- **v1.0 — Stable Reader:** accessibility and upgrade hardening, full supported-platform release matrix, long-session soak evidence, and a frozen public behavior contract.
+- **v0.7.x — Reader Engine:** shipped the session controller, exact pause/resume, live pitch-preserved speed, structural clipboard planning, startup prewarm, and first-audio feedback.
+- **v0.8.x — Speech Intelligence:** ship deliberate handling for numbers and technical text, retained-line-break pauses, replay-current-sentence, voice preview, model consistency, startup diagnostics, and signed updater bootstrap.
+- **v1.0 — Stable Reader:** next mainline target. Focus on accessibility, update verification, full supported-platform release evidence, crash recovery, and long-session soak testing.
+- **Post-1.0 Engine Lab:** optional model/backend experiments remain evidence-gated and do not block v1.0. Kokoro stays the offline default unless another engine delivers a material listening-quality win without unacceptable package or platform costs.
 
 ## Progress ledger
 
@@ -20,30 +20,34 @@ Working release name: **Reader Engine**
 - W0.5 fake audio integration harness: the production queue player runs against fake streams with exact offset, multi-chunk ordering, failed-write, cancellation, 50-thread replacement-race, and 500-chunk bounded-queue coverage; real-time 30-minute soak remains a release gate.
 - W1.0 clipboard structure recovery: a native command reads both plain text and HTML where the source app provides them; matching HTML is converted to local structural hints, mismatches fall back to plain text, and high-confidence plain heading inference is fixture-locked. Cross-app manual verification remains.
 - W1.1–W1.2 structural planner: headings, paragraphs, lists, quotes, code source mapping, bounded sentence/clause segmentation, and segment-specific pauses implemented locally.
-- W1.3 normalization rules: conservative spoken forms for Okay/idk/lol/TBH/imo and stronger informal ellipsis pauses are fixture-locked; numbers, technical text, and user overrides remain pending.
+- W1.3 normalization rules: conversational shorthand, common uppercase initialisms, informal ellipsis pauses, and word-collision counterexamples are fixture-locked.
+- W1.4 number/technical normalization: currency, percentages, ISO dates, clock times, versions, speed multipliers, URLs, email addresses, paths, and inline code have approved spoken-form fixtures; locale selection, long digit policy, and user overrides remain.
 - W1.5 code behavior: code blocks are always announced, read with identifier/operator normalization by default, and announced as skipped only when the stored setting is enabled; broader code fixtures remain pending.
 - W2.1/W2.8 session controller: per-request cancellation, pause state, chunk/sample position, serialized inference, cancellation-aware queue backpressure, stale-control rejection, and deterministic replacement-race tests implemented locally; live overlap test pending.
 - W2.2 persistent queue player: production playback state machine extracted behind a sounddevice-independent stream contract and covered by integration tests; packaged-device testing pending.
 - W2.3 exact pause/resume: sample-offset retention implemented locally; live and packaged-app acceptance measurements pending.
+- W2.4 sentence navigation: compact replay-current-sentence control and Option/Alt+Left shortcut implemented; forward skip is intentionally omitted.
 - W2.6–W2.7 runtime speed: Apache-2.0 Sonic is vendored behind a small streaming C ABI, applies speed changes between 20 ms source blocks, and is wired through UI, Tauri, session state, playback, local build, and release packaging. Native and signed frozen macOS arm64 startup tests pass; Windows, macOS x64, command-to-audible measurement, and human listening gates remain.
 - W3.1–W3.2 latency path: default engine prewarms before health/ready, the fixed 100 ms request delay is removed, and the 250 ms first-buffer silence is replaced by concurrent output-stream warmup; live clipping check pending.
 - W3.4–W3.6 first-audio feedback: rolling local median keyed by backend, voice, and first-segment-size bucket; low-confidence indeterminate state; conservative 90%-capped bar; and half-second remaining-time label implemented. Playback-remaining estimate is pending.
+- W3.7 compact packaging: unused ONNX/test modules were removed from the frozen build, producing an approximately 503 MB Apple Silicon candidate. A roughly 1 GB pre-extracted runtime improved repeat startup but was rejected as a poor product tradeoff; the compact offline build remains the release path.
+- W6 update/recovery: signed updater metadata, download progress, install/restart controls, startup milestones, saved-shortcut restoration, and version display are implemented. v0.8.0 bootstraps the signing channel; v0.8.1 must prove an installed update from v0.8.0.
 - W4.2 backend benchmark: corpus-driven PyTorch CPU/MPS runner and initial M2 reference suite implemented; Windows/CUDA and frozen-package measurements pending.
 - W5.3 Pocket TTS benchmark: isolated v2.1.0 CPU streaming runner and initial M2 unquantized/quantized measurements implemented; blind quality and frozen-package work pending.
 - Remaining W1–W6 work: active, sequenced below; engine promotion remains evidence-gated.
 
 ## Release outcome
 
-v0.7 should make reading feel immediate, controllable, and deliberately spoken rather than merely converting a flattened clipboard string into audio.
+v0.8 should make reading feel deliberate and dependable without increasing the installed footprint or replacing the proven Kokoro default.
 
 The release is successful when it:
 
-1. pauses and resumes at the actual playback position;
-2. applies speed changes predictably without replaying text or changing pitch;
-3. preserves useful document structure and handles common shorthand, numbers, and code intentionally;
-4. starts audible playback materially faster and reports honest progress while waiting;
-5. includes a measured experimental acceleration/model path without weakening the stable offline default; and
-6. adds sentence navigation and remaining-time feedback so users can control longer readings.
+1. preserves useful document structure and handles common shorthand, numbers, links, paths, and code intentionally;
+2. adds a compact replay-current-sentence action without a forward-skip button;
+3. previews voices before saving and restores customized shortcuts on restart;
+4. reports honest cold-start and first-audio progress while retaining the compact offline package;
+5. eliminates training-mode variability in Kokoro inference; and
+6. bootstraps signed cross-platform updates for verification in the first v0.8 patch release.
 
 This roadmap separates model inference, speech planning, and audio playback. That separation is required: changing models alone cannot recover formatting that the app discarded or fix playback state that the app never tracked.
 
@@ -68,7 +72,7 @@ Confirmed with the product owner on 2026-07-25. Primary-content weighting and fi
 | Code blocks | Always announce code blocks; read them intelligently by default; skip only when the user enables the setting | Requires a stored setting plus concise identifier/operator normalization |
 | Informal shorthand | `idk`, `lol`, `TBH`, and `imo` are pronounced as initialisms for now; later user dictionary rules override built-ins | Changes default lexicon fixtures only |
 | Experimental models | Pocket TTS may be offered as an opt-in on-device engine; Kokoro remains the installed fallback until quality and packaging gates pass | Requires in-app lifecycle/download UX and engine-specific voices/settings |
-| Release numbering | Ship this work as v0.7.0, not v1.0 | A v1.0 designation would require a broader stability/support commitment |
+| Release numbering | Ship Speech Intelligence as v0.8.0, then target v1.0 hardening directly | A mandatory v0.9 engine release would delay stability work without a demonstrated user benefit |
 
 ## v0.6.3 baseline evidence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tauri-apps/plugin-global-shortcut": "^2.3.1",
         "@tauri-apps/plugin-log": "^2.8.0",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-store": "^2.4.2",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "react": "^19.1.0",
@@ -2353,6 +2354,15 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
       "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-store": "^2.4.2",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ loguru
 # Transformers 5 requires PyTorch >=2.4 and disables the Intel macOS wheel.
 # Kokoro 0.9.4 uses the stable Transformers 4 Albert API.
 transformers==4.57.6
-onnxruntime
 misaki[en]>=0.9.4
 phonemizer-fork==3.3.2
 language_tags

--- a/scripts/build_local_sidecar.py
+++ b/scripts/build_local_sidecar.py
@@ -57,20 +57,14 @@ def run():
         venv_pyinstaller,
         "--onefile",
         "--name", "kokoro",
-        "--collect-all", "onnxruntime",
         "--collect-all", "kokoro",
         "--collect-all", "misaki",
         "--collect-all", "phonemizer",
         "--collect-all", "language_tags",
         "--collect-all", "espeakng_loader",
-        "--collect-all", "huggingface_hub",
-        "--collect-all", "sounddevice",
-        "--collect-all", "soundfile",
-        "--collect-all", "torch",
-        "--collect-all", "loguru",
-        "--collect-all", "transformers",
-        "--collect-all", "spacy",
         "--collect-all", "en_core_web_sm",
+        "--exclude-module", "onnxruntime",
+        "--exclude-module", "spacy.tests",
     ]
     if os.name == 'nt':
         sonic_library = os.path.join("sidecar", "native", "sonic_kctts.dll")

--- a/sidecar/kokoro_server.py
+++ b/sidecar/kokoro_server.py
@@ -51,7 +51,6 @@ if sys.platform == "win32" and getattr(sys, "frozen", False):
         _bundle,
         os.path.join(_bundle, "torch", "lib"),          # torch_cpu.dll, c10.dll …
         os.path.join(_bundle, "espeakng_loader"),        # espeak-ng.dll
-        os.path.join(_bundle, "onnxruntime", "capi"),    # onnxruntime.dll
     ]
     for _d in _dll_search:
         if os.path.isdir(_d):
@@ -140,7 +139,14 @@ def get_pipeline():
                     if os.path.isfile(config_path) and os.path.isfile(model_path):
                         print("[Sidecar] Loading bundled model weights.")
                         repo_id = "hexgrad/Kokoro-82M"
-                        model = KModel(repo_id=repo_id, config=config_path, model=model_path)
+                        # KPipeline only calls eval() when it constructs the model
+                        # itself. We pass a preloaded offline model, so explicitly
+                        # disable training-time dropout for stable prosody.
+                        model = KModel(
+                            repo_id=repo_id,
+                            config=config_path,
+                            model=model_path,
+                        ).eval()
                         pipeline = KPipeline(lang_code='a', repo_id=repo_id, model=model)
                     else:
                         print("[Sidecar] Bundled weights not found; downloading from Hugging Face.")

--- a/sidecar/kokoro_server.py
+++ b/sidecar/kokoro_server.py
@@ -10,12 +10,14 @@ try:
     from .tts_protocol import encode_tts_event, normalize_synthesis_segments
     from .audio_playback import AudioChunk, play_queued_audio
     from .playback_session import PlaybackSessionController
+    from .pipeline_loader import create_offline_pipeline
     from .sonic_speed import SonicSpeedProcessor
 except ImportError:
     # Script/PyInstaller execution places the sidecar directory on sys.path.
     from tts_protocol import encode_tts_event, normalize_synthesis_segments
     from audio_playback import AudioChunk, play_queued_audio
     from playback_session import PlaybackSessionController
+    from pipeline_loader import create_offline_pipeline
     from sonic_speed import SonicSpeedProcessor
 
 # Make stdout write-through (unbuffered) so every write is flushed to disk
@@ -139,15 +141,13 @@ def get_pipeline():
                     if os.path.isfile(config_path) and os.path.isfile(model_path):
                         print("[Sidecar] Loading bundled model weights.")
                         repo_id = "hexgrad/Kokoro-82M"
-                        # KPipeline only calls eval() when it constructs the model
-                        # itself. We pass a preloaded offline model, so explicitly
-                        # disable training-time dropout for stable prosody.
-                        model = KModel(
+                        pipeline = create_offline_pipeline(
+                            KModel,
+                            KPipeline,
                             repo_id=repo_id,
-                            config=config_path,
-                            model=model_path,
-                        ).eval()
-                        pipeline = KPipeline(lang_code='a', repo_id=repo_id, model=model)
+                            config_path=config_path,
+                            model_path=model_path,
+                        )
                     else:
                         print("[Sidecar] Bundled weights not found; downloading from Hugging Face.")
                         pipeline = KPipeline(lang_code='a')

--- a/sidecar/pipeline_loader.py
+++ b/sidecar/pipeline_loader.py
@@ -1,0 +1,17 @@
+def create_offline_pipeline(
+    model_class,
+    pipeline_class,
+    *,
+    repo_id,
+    config_path,
+    model_path,
+):
+    """Build an offline Kokoro pipeline with inference-only model behavior."""
+    # KPipeline only calls eval() when it constructs the model itself. The app
+    # passes a preloaded model, so disable training-time dropout explicitly.
+    model = model_class(
+        repo_id=repo_id,
+        config=config_path,
+        model=model_path,
+    ).eval()
+    return pipeline_class(lang_code="a", repo_id=repo_id, model=model)

--- a/sidecar/test_kokoro_server.py
+++ b/sidecar/test_kokoro_server.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch
+
+try:
+    from . import kokoro_server
+except ImportError:
+    import kokoro_server
+
+
+class FakeModel:
+    def __init__(self, **_kwargs):
+        self.training = True
+
+    def eval(self):
+        self.training = False
+        return self
+
+
+class PipelineInitializationTests(unittest.TestCase):
+    def tearDown(self):
+        kokoro_server.pipeline = None
+
+    def test_preloaded_offline_model_uses_evaluation_mode(self):
+        created = {}
+
+        def fake_pipeline(*, model, **_kwargs):
+            created["model"] = model
+            return object()
+
+        kokoro_server.pipeline = None
+        with (
+            patch.object(kokoro_server, "KModel", FakeModel),
+            patch.object(kokoro_server, "KPipeline", side_effect=fake_pipeline),
+        ):
+            kokoro_server.get_pipeline()
+
+        self.assertFalse(created["model"].training)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sidecar/test_kokoro_server.py
+++ b/sidecar/test_kokoro_server.py
@@ -1,10 +1,9 @@
 import unittest
-from unittest.mock import patch
 
 try:
-    from . import kokoro_server
+    from .pipeline_loader import create_offline_pipeline
 except ImportError:
-    import kokoro_server
+    from pipeline_loader import create_offline_pipeline
 
 
 class FakeModel:
@@ -17,9 +16,6 @@ class FakeModel:
 
 
 class PipelineInitializationTests(unittest.TestCase):
-    def tearDown(self):
-        kokoro_server.pipeline = None
-
     def test_preloaded_offline_model_uses_evaluation_mode(self):
         created = {}
 
@@ -27,12 +23,13 @@ class PipelineInitializationTests(unittest.TestCase):
             created["model"] = model
             return object()
 
-        kokoro_server.pipeline = None
-        with (
-            patch.object(kokoro_server, "KModel", FakeModel),
-            patch.object(kokoro_server, "KPipeline", side_effect=fake_pipeline),
-        ):
-            kokoro_server.get_pipeline()
+        create_offline_pipeline(
+            FakeModel,
+            fake_pipeline,
+            repo_id="hexgrad/Kokoro-82M",
+            config_path="config.json",
+            model_path="kokoro-v1_0.pth",
+        )
 
         self.assertFalse(created["model"].training)
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arboard",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2313,6 +2313,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
@@ -4838,6 +4839,16 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 tauri-plugin-log = "2.8.0"
 arboard = { version = "3.6.1", default-features = false }
+tauri-plugin-process = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.7.1"
+version = "0.8.0"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,7 @@
     "global-shortcut:allow-unregister",
     "global-shortcut:allow-is-registered",
     "updater:default",
+    "process:allow-restart",
     "store:default",
     "dialog:default",
     "dialog:allow-message",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -284,7 +284,11 @@ fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
                 }
             }
             "check_updates" => {
-                let _ = app.emit("check-for-updates", ());
+                if let Some(win) = app.get_webview_window("settings") {
+                    let _ = win.show();
+                    let _ = win.set_focus();
+                    let _ = win.emit("check-for-updates", ());
+                }
             }
             "tutorial" => {
                 if let Some(win) = app.get_webview_window("tutorial") {
@@ -344,6 +348,7 @@ pub fn run() {
         .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -23,6 +23,16 @@ fn parse_tts_event(line: &str) -> Option<TtsEvent> {
     serde_json::from_str(payload).ok()
 }
 
+fn startup_status_for_line(line: &str) -> Option<&'static str> {
+    if line.contains("[Sidecar] Initializing Kokoro Pipeline") {
+        Some("loading-model")
+    } else if line.contains("[Sidecar] Pipeline initialized successfully") {
+        Some("warming-engine")
+    } else {
+        None
+    }
+}
+
 /// Manages the lifecycle of the Kokoro TTS sidecar process.
 ///
 /// The sidecar is a PyInstaller-built Python executable that runs a local
@@ -249,6 +259,8 @@ impl SidecarManager {
                                 }
                             }
                             let _ = handle_for_stdout.emit("tts-event", tts_event);
+                        } else if let Some(startup_status) = startup_status_for_line(&line_str) {
+                            let _ = handle_for_stdout.emit("sidecar-status", startup_status);
                         } else if line_str.contains("Chunk 0") {
                             let _ = handle_for_stdout.emit("tts-speaking", ());
                         } else if line_str.contains("[STATUS] FINISHED") {
@@ -407,7 +419,7 @@ impl Drop for SidecarManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_tts_event, TTS_EVENT_PREFIX};
+    use super::{parse_tts_event, startup_status_for_line, TTS_EVENT_PREFIX};
 
     #[test]
     fn parses_structured_tts_event() {
@@ -430,5 +442,18 @@ mod tests {
         assert!(parse_tts_event("[Sidecar] Generated chunk 0").is_none());
         assert!(parse_tts_event(TTS_EVENT_PREFIX).is_none());
         assert!(parse_tts_event("[TTS_EVENT] {not-json}").is_none());
+    }
+
+    #[test]
+    fn identifies_real_startup_milestones() {
+        assert_eq!(
+            startup_status_for_line("[Sidecar] Initializing Kokoro Pipeline..."),
+            Some("loading-model")
+        );
+        assert_eq!(
+            startup_status_for_line("[Sidecar] Pipeline initialized successfully."),
+            Some("warming-engine")
+        );
+        assert_eq!(startup_status_for_line("ordinary log line"), None);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -93,7 +93,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "YOUR_UPDATER_PUBLIC_KEY_HERE",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQyMjM2Mjg4ODBFMkQ2OEIKUldTTDF1S0FpR0lqUWtTUzE5T0prOTkxK1hVS2kwUzB5aXVodzJCaWxPeDYwR21za2xOekc2Z3UK",
       "endpoints": [
         "https://github.com/seanbud/Kokoro-Clipboard-TTS/releases/latest/download/latest.json"
       ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/FloatingWidget.tsx
+++ b/src/components/FloatingWidget.tsx
@@ -8,7 +8,11 @@ import {
   structuredClipboardText,
   type ClipboardPayload,
 } from "../utils/clipboardStructure";
-import { planTextForTTS, type SpeechSegment } from "../utils/speechPlanner";
+import {
+  planTextForTTS,
+  replayPlanFromSegment,
+  type SpeechSegment,
+} from "../utils/speechPlanner";
 import {
   estimateFirstAudioMs,
   estimatedGenerationProgress,
@@ -59,6 +63,12 @@ const StopIcon = () => (
   </svg>
 );
 
+const ReplayIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="w-4 h-4">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v6h6M5.5 15a7 7 0 1 0 1.1-7.8L4 10" />
+  </svg>
+);
+
 const CloseIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="w-4 h-4">
     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -80,6 +90,7 @@ export default function FloatingWidget() {
   const [subtleFlashKey, setSubtleFlashKey] = useState(0); // tiny dot pulse (on global copy)
   const [generationElapsedMs, setGenerationElapsedMs] = useState(0);
   const [firstAudioContext, setFirstAudioContext] = useState<FirstAudioContext | null>(null);
+  const [canReplay, setCanReplay] = useState(false);
   const hasEnteredRef = useRef(false);
   const speedIndexRef = useRef(DEFAULT_SPEED_INDEX);
   const storeRef = useRef<Awaited<ReturnType<typeof load>> | null>(null);
@@ -88,6 +99,7 @@ export default function FloatingWidget() {
   const firstAudioContextRef = useRef<FirstAudioContext | null>(null);
   const firstAudioHistoryRef = useRef<FirstAudioSample[]>([]);
   const skipCodeBlocksRef = useRef(false);
+  const replaySegmentIdRef = useRef<string | null>(null);
 
   const speed = SPEED_NOTCHES[speedIndex];
   const lastSpeechPlan = useRef<SpeechSegment[]>([]);
@@ -149,20 +161,24 @@ export default function FloatingWidget() {
 
       if (lifecycle.event === "request_received") {
         requestReceivedAtRef.current = lifecycle.timestampMs;
-      } else if (
-        lifecycle.event === "playback_started"
-        && requestReceivedAtRef.current !== null
-        && firstAudioContextRef.current !== null
-      ) {
-        const durationMs = lifecycle.timestampMs - requestReceivedAtRef.current;
-        const nextHistory = recordFirstAudioSample(
-          firstAudioHistoryRef.current,
-          durationMs,
-          firstAudioContextRef.current,
-        );
-        firstAudioHistoryRef.current = nextHistory;
-        requestReceivedAtRef.current = null;
-        void storeRef.current?.set(FIRST_AUDIO_HISTORY_KEY, nextHistory);
+      } else if (lifecycle.event === "playback_started") {
+        if (typeof lifecycle.data.segmentId === "string") {
+          replaySegmentIdRef.current = lifecycle.data.segmentId;
+        }
+        if (
+          requestReceivedAtRef.current !== null
+          && firstAudioContextRef.current !== null
+        ) {
+          const durationMs = lifecycle.timestampMs - requestReceivedAtRef.current;
+          const nextHistory = recordFirstAudioSample(
+            firstAudioHistoryRef.current,
+            durationMs,
+            firstAudioContextRef.current,
+          );
+          firstAudioHistoryRef.current = nextHistory;
+          requestReceivedAtRef.current = null;
+          void storeRef.current?.set(FIRST_AUDIO_HISTORY_KEY, nextHistory);
+        }
       }
 
       const nextStatus = statusForTtsEvent(lifecycle);
@@ -225,6 +241,7 @@ export default function FloatingWidget() {
           pauseAfterMs,
         }));
       if (synthesisSegments.length === 0) return;
+      replaySegmentIdRef.current = synthesisSegments[0].id;
 
       const requestId = crypto.randomUUID();
       activeRequestIdRef.current = requestId;
@@ -274,6 +291,7 @@ export default function FloatingWidget() {
             skipCodeBlocks: skipCodeBlocksRef.current,
           });
           lastSpeechPlan.current = speechPlan;
+          setCanReplay(speechPlan.some((segment) => Boolean(segment.spokenText)));
 
           // Fixes #11: flash the widget to confirm clipboard text received
           setFlashKey((k) => k + 1);
@@ -352,6 +370,27 @@ export default function FloatingWidget() {
     setIsPlaying(false);
     setStatus("Idle");
   }, []);
+
+  // ── Replay current sentence ──
+  const handleReplay = useCallback(async () => {
+    if (lastSpeechPlan.current.length === 0) return;
+    const replayPlan = replayPlanFromSegment(
+      lastSpeechPlan.current,
+      replaySegmentIdRef.current,
+    );
+    await runTTS(replayPlan);
+  }, [speed]);
+
+  useEffect(() => {
+    const handleReplayShortcut = (event: KeyboardEvent) => {
+      if (event.altKey && event.key === "ArrowLeft") {
+        event.preventDefault();
+        void handleReplay();
+      }
+    };
+    window.addEventListener("keydown", handleReplayShortcut);
+    return () => window.removeEventListener("keydown", handleReplayShortcut);
+  }, [handleReplay]);
 
   // ── Close ──
   const handleClose = useCallback(async () => {
@@ -443,6 +482,23 @@ export default function FloatingWidget() {
           "
         >
           <StopIcon />
+        </button>
+
+        {/* Replay Current Sentence */}
+        <button
+          type="button"
+          onClick={handleReplay}
+          onMouseDown={(e) => e.stopPropagation()}
+          disabled={!canReplay}
+          title={`Replay current sentence (${navigator.platform.includes("Mac") ? "⌥←" : "Alt+←"})`}
+          className="
+            w-7 h-7 rounded-full flex items-center justify-center shrink-0
+            bg-white/5 hover:bg-white/10 disabled:opacity-25 disabled:hover:bg-white/5
+            active:scale-95 transition-smooth
+            text-white/55 cursor-default
+          "
+        >
+          <ReplayIcon />
         </button>
 
         {/* Status Hub */}

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { load } from "@tauri-apps/plugin-store";
 import { register, unregister, isRegistered } from "@tauri-apps/plugin-global-shortcut";
+import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { check, type Update } from "@tauri-apps/plugin-updater";
 import {
   eventBelongsToRequest,
   type TtsLifecycleEvent,
 } from "../utils/ttsEvents";
+import {
+  EMPTY_UPDATE_PROGRESS,
+  updateDownloadProgress,
+  type UpdateDownloadProgress,
+} from "../utils/updateProgress";
 
 // ─── Kokoro voice presets ──────────────────────────────────────────────────
 const VOICE_PRESETS = [
@@ -25,6 +33,7 @@ const DEFAULT_SHORTCUT_MAC = "Control+Option+R";
 const VOICE_PREVIEW_TEXT = "Okay, this is how I'll sound while reading for you.";
 
 type VoicePreviewState = "idle" | "preparing" | "playing";
+type UpdaterState = "idle" | "checking" | "current" | "available" | "downloading" | "ready" | "error";
 
 function getPlatformDefault() {
   return navigator.userAgent.includes("Mac")
@@ -43,6 +52,13 @@ export default function SettingsWindow() {
   const [voicePreviewState, setVoicePreviewState] = useState<VoicePreviewState>("idle");
   const [voicePreviewError, setVoicePreviewError] = useState("");
   const voicePreviewRequestIdRef = useRef<string | null>(null);
+  const [appVersion, setAppVersion] = useState("");
+  const [updaterState, setUpdaterState] = useState<UpdaterState>("idle");
+  const [availableVersion, setAvailableVersion] = useState("");
+  const [updateError, setUpdateError] = useState("");
+  const [downloadProgress, setDownloadProgress] = useState<UpdateDownloadProgress>(EMPTY_UPDATE_PROGRESS);
+  const availableUpdateRef = useRef<Update | null>(null);
+  const updaterBusyRef = useRef(false);
   
   const [devices, setDevices] = useState<{id: number, name: string}[]>([]);
   const [currentDevice, setCurrentDevice] = useState<number>(0);
@@ -52,9 +68,22 @@ export default function SettingsWindow() {
     getCurrentWebviewWindow().startDragging();
   };
 
+  // Keep the preloaded Settings webview alive so tray actions and long-running
+  // update downloads retain their state when the native close button is used.
+  useEffect(() => {
+    const win = getCurrentWebviewWindow();
+    const unlisten = win.onCloseRequested((event) => {
+      event.preventDefault();
+      void win.hide();
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, []);
+
   // ── Load settings ──
   useEffect(() => {
     (async () => {
+      getVersion().then(setAppVersion).catch(() => {});
+
       // 1. Fetch sidecar audio devices
       try {
         const devRes = await invoke<any>("get_audio_devices");
@@ -150,6 +179,70 @@ export default function SettingsWindow() {
       setVoicePreviewState("idle");
     }
   }, [voice, volume]);
+
+  // ── Signed application updates ──
+  const handleCheckForUpdates = useCallback(async () => {
+    if (updaterBusyRef.current) return;
+    updaterBusyRef.current = true;
+    setUpdaterState("checking");
+    setUpdateError("");
+
+    try {
+      if (availableUpdateRef.current) {
+        await availableUpdateRef.current.close().catch(() => {});
+        availableUpdateRef.current = null;
+      }
+      const update = await check({ timeout: 20_000 });
+      if (update) {
+        availableUpdateRef.current = update;
+        setAvailableVersion(update.version);
+        setUpdaterState("available");
+      } else {
+        setAvailableVersion("");
+        setUpdaterState("current");
+      }
+    } catch (error) {
+      setUpdateError(String(error));
+      setUpdaterState("error");
+    } finally {
+      updaterBusyRef.current = false;
+    }
+  }, []);
+
+  const handleInstallUpdate = useCallback(async () => {
+    const update = availableUpdateRef.current;
+    if (!update || updaterBusyRef.current) return;
+    updaterBusyRef.current = true;
+    setUpdaterState("downloading");
+    setUpdateError("");
+    setDownloadProgress(EMPTY_UPDATE_PROGRESS);
+
+    try {
+      await update.downloadAndInstall((event) => {
+        setDownloadProgress((current) => updateDownloadProgress(current, event));
+      });
+      availableUpdateRef.current = null;
+      setUpdaterState("ready");
+    } catch (error) {
+      await update.close().catch(() => {});
+      availableUpdateRef.current = null;
+      setUpdateError(String(error));
+      setUpdaterState("error");
+    } finally {
+      updaterBusyRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen("check-for-updates", () => {
+      void handleCheckForUpdates();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+      availableUpdateRef.current?.close().catch(() => {});
+      availableUpdateRef.current = null;
+    };
+  }, [handleCheckForUpdates]);
 
   // ── Save settings ──
   const handleSave = useCallback(async () => {
@@ -383,6 +476,56 @@ export default function SettingsWindow() {
               className={`absolute top-0.5 w-4 h-4 rounded-full shadow-sm transition-smooth ${shortcutEnabled ? "left-5.5 bg-[#202124]" : "left-0.5 bg-white/40"}`}
             />
           </button>
+        </div>
+
+        {/* Application updates */}
+        <div className="space-y-3 rounded-2xl border border-white/10 bg-white/[0.025] p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="text-sm text-white/70">Application Updates</div>
+              <p className="mt-1 text-[11px] leading-relaxed text-white/35" aria-live="polite">
+                {updaterState === "checking" && "Checking GitHub Releases…"}
+                {updaterState === "current" && `You're up to date${appVersion ? ` on v${appVersion}` : ""}.`}
+                {updaterState === "available" && `Version ${availableVersion} is ready to download.`}
+                {updaterState === "downloading" && (downloadProgress.percent !== null
+                  ? `Downloading version ${availableVersion} — ${downloadProgress.percent}%`
+                  : `Downloading version ${availableVersion}…`)}
+                {updaterState === "ready" && `Version ${availableVersion} is installed. Restart to finish.`}
+                {updaterState === "error" && (updateError || "The update check failed. Please try again.")}
+                {updaterState === "idle" && `Installed version${appVersion ? `: v${appVersion}` : ""}.`}
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={updaterState === "checking" || updaterState === "downloading"}
+              onClick={() => {
+                if (updaterState === "available") void handleInstallUpdate();
+                else if (updaterState === "ready") void relaunch();
+                else void handleCheckForUpdates();
+              }}
+              className="shrink-0 min-w-24 px-4 py-2 rounded-xl text-xs font-semibold bg-white/5 border border-white/10 hover:bg-white/10 disabled:opacity-40 disabled:cursor-wait transition-smooth text-white/60 hover:text-[#8AB4F8]"
+            >
+              {updaterState === "checking"
+                ? "Checking…"
+                : updaterState === "available"
+                  ? "Install"
+                  : updaterState === "downloading"
+                    ? "Installing…"
+                    : updaterState === "ready"
+                      ? "Restart"
+                      : updaterState === "error"
+                        ? "Retry"
+                        : "Check"}
+            </button>
+          </div>
+          {updaterState === "downloading" && (
+            <div className="h-1.5 overflow-hidden rounded-full bg-white/5" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={downloadProgress.percent ?? undefined}>
+              <div
+                className={`h-full rounded-full bg-[#8AB4F8] transition-[width] duration-300 ${downloadProgress.percent === null ? "w-1/3 animate-pulse" : ""}`}
+                style={downloadProgress.percent === null ? undefined : { width: `${downloadProgress.percent}%` }}
+              />
+            </div>
+          )}
         </div>
 
         {/* Save */}

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { load } from "@tauri-apps/plugin-store";
 import { register, unregister, isRegistered } from "@tauri-apps/plugin-global-shortcut";
 import { invoke } from "@tauri-apps/api/core";
-import { emit } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
+import {
+  eventBelongsToRequest,
+  type TtsLifecycleEvent,
+} from "../utils/ttsEvents";
 
 // ─── Kokoro voice presets ──────────────────────────────────────────────────
 const VOICE_PRESETS = [
@@ -18,6 +22,9 @@ const VOICE_PRESETS = [
 const DEFAULT_VOICE = "am_fenrir";
 const DEFAULT_SHORTCUT_WIN = "Super+Shift+Q";
 const DEFAULT_SHORTCUT_MAC = "Control+Option+R";
+const VOICE_PREVIEW_TEXT = "Okay, this is how I'll sound while reading for you.";
+
+type VoicePreviewState = "idle" | "preparing" | "playing";
 
 function getPlatformDefault() {
   return navigator.userAgent.includes("Mac")
@@ -33,6 +40,9 @@ export default function SettingsWindow() {
   const [saved, setSaved] = useState(false);
   const [volume, setVolume] = useState(1.0);
   const [skipCodeBlocks, setSkipCodeBlocks] = useState(false);
+  const [voicePreviewState, setVoicePreviewState] = useState<VoicePreviewState>("idle");
+  const [voicePreviewError, setVoicePreviewError] = useState("");
+  const voicePreviewRequestIdRef = useRef<string | null>(null);
   
   const [devices, setDevices] = useState<{id: number, name: string}[]>([]);
   const [currentDevice, setCurrentDevice] = useState<number>(0);
@@ -72,6 +82,74 @@ export default function SettingsWindow() {
       if (typeof skipCode === "boolean") setSkipCodeBlocks(skipCode);
     })();
   }, []);
+
+  // ── Voice preview lifecycle ──
+  useEffect(() => {
+    const unlisten = listen<TtsLifecycleEvent>("tts-event", (event) => {
+      const lifecycle = event.payload;
+      if (!eventBelongsToRequest(lifecycle, voicePreviewRequestIdRef.current)) return;
+
+      if (lifecycle.event === "playback_started") {
+        setVoicePreviewState("playing");
+      } else if (
+        lifecycle.event === "cancelled"
+        || lifecycle.event === "playback_finished"
+      ) {
+        voicePreviewRequestIdRef.current = null;
+        setVoicePreviewState("idle");
+      } else if (lifecycle.event === "error") {
+        const message = typeof lifecycle.data.message === "string"
+          ? lifecycle.data.message
+          : "Voice preview failed";
+        voicePreviewRequestIdRef.current = null;
+        setVoicePreviewError(message);
+        setVoicePreviewState("idle");
+      }
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+      const requestId = voicePreviewRequestIdRef.current;
+      voicePreviewRequestIdRef.current = null;
+      if (requestId) void invoke("stop_tts", { requestId }).catch(() => {});
+    };
+  }, []);
+
+  const handleVoicePreview = useCallback(async () => {
+    const activeRequestId = voicePreviewRequestIdRef.current;
+    if (activeRequestId) {
+      voicePreviewRequestIdRef.current = null;
+      setVoicePreviewState("idle");
+      await invoke("stop_tts", { requestId: activeRequestId }).catch(() => {});
+      return;
+    }
+
+    const requestId = crypto.randomUUID();
+    voicePreviewRequestIdRef.current = requestId;
+    setVoicePreviewError("");
+    setVoicePreviewState("preparing");
+
+    try {
+      await invoke("send_to_tts", {
+        text: VOICE_PREVIEW_TEXT,
+        speed: 1.0,
+        voice,
+        volume,
+        requestId,
+        segments: [{
+          id: "voice-preview",
+          kind: "sentence",
+          spokenText: VOICE_PREVIEW_TEXT,
+          pauseAfterMs: 0,
+        }],
+      });
+    } catch (error) {
+      if (voicePreviewRequestIdRef.current !== requestId) return;
+      voicePreviewRequestIdRef.current = null;
+      setVoicePreviewError(String(error));
+      setVoicePreviewState("idle");
+    }
+  }, [voice, volume]);
 
   // ── Save settings ──
   const handleSave = useCallback(async () => {
@@ -162,17 +240,34 @@ export default function SettingsWindow() {
           <label className="text-xs font-medium text-white/50 uppercase tracking-wider">
             Voice Preset
           </label>
-          <select
-            value={voice}
-            onChange={(e) => setVoice(e.target.value)}
-            className="w-full px-4 py-2.5 rounded-xl bg-[#2D2D2D] border border-white/10 text-sm text-white/90 focus:outline-none focus:border-[#8AB4F8]/50 transition-smooth cursor-pointer"
-          >
-            {VOICE_PRESETS.map((v) => (
-              <option key={v} value={v} className="bg-[#2D2D2D]">
-                {v.replace("_", " ").replace(/\b\w/g, (c) => c.toUpperCase())}
-              </option>
-            ))}
-          </select>
+          <div className="flex gap-2">
+            <select
+              value={voice}
+              onChange={(e) => setVoice(e.target.value)}
+              className="min-w-0 flex-1 px-4 py-2.5 rounded-xl bg-[#2D2D2D] border border-white/10 text-sm text-white/90 focus:outline-none focus:border-[#8AB4F8]/50 transition-smooth cursor-pointer"
+            >
+              {VOICE_PRESETS.map((v) => (
+                <option key={v} value={v} className="bg-[#2D2D2D]">
+                  {v.replace("_", " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handleVoicePreview}
+              title={voicePreviewState === "idle" ? "Hear this voice" : "Stop voice preview"}
+              className={`min-w-24 px-4 py-2.5 rounded-xl text-xs font-semibold border transition-smooth ${voicePreviewState === "idle" ? "bg-white/5 border-white/10 hover:bg-white/10 text-white/60 hover:text-[#8AB4F8]" : "bg-[#1C2B41] border-[#8AB4F8]/30 text-[#AECBFA] hover:bg-[#233752]"}`}
+            >
+              {voicePreviewState === "preparing"
+                ? "Preparing…"
+                : voicePreviewState === "playing"
+                  ? "Stop"
+                  : "Preview"}
+            </button>
+          </div>
+          <p className={`min-h-4 text-[11px] leading-4 ${voicePreviewError ? "text-red-300/80" : "text-white/30"}`} aria-live="polite">
+            {voicePreviewError || (voicePreviewState === "idle" ? "Uses the selected voice and volume before saving." : "Preview replaces any speech already playing.")}
+          </p>
         </div>
 
         {/* Audio Output Device */}

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -41,6 +41,24 @@ function getPlatformDefault() {
     : DEFAULT_SHORTCUT_WIN;
 }
 
+async function applyGlobalShortcut(shortcut: string, enabled: boolean) {
+  const platformDefault = getPlatformDefault();
+  if (await isRegistered(platformDefault)) {
+    await unregister(platformDefault);
+  }
+  if (shortcut !== platformDefault && await isRegistered(shortcut)) {
+    await unregister(shortcut);
+  }
+
+  if (enabled) {
+    await register(shortcut, (event) => {
+      if (event.state === "Pressed") {
+        void emit("shortcut-triggered");
+      }
+    });
+  }
+}
+
 export default function SettingsWindow() {
   const [voice, setVoice] = useState(DEFAULT_VOICE);
   const [shortcut, setShortcut] = useState(getPlatformDefault());
@@ -100,9 +118,16 @@ export default function SettingsWindow() {
       const v = await store.get<string>("voice");
       if (v) setVoice(v);
       const s = await store.get<string>("shortcut");
-      if (s) setShortcut(s);
       const e = await store.get<boolean>("shortcut-enabled");
-      if (e !== null && e !== undefined) setShortcutEnabled(e);
+      const savedShortcut = s || getPlatformDefault();
+      const savedShortcutEnabled = e ?? true;
+      setShortcut(savedShortcut);
+      setShortcutEnabled(savedShortcutEnabled);
+      try {
+        await applyGlobalShortcut(savedShortcut, savedShortcutEnabled);
+      } catch (error) {
+        console.error("Failed to restore shortcut:", error);
+      }
       const vol = await store.get<number>("volume");
       if (typeof vol === 'number') {
         setVolume(vol);
@@ -255,23 +280,8 @@ export default function SettingsWindow() {
     await store.save();
     await emit("settings-updated", { skipCodeBlocks });
 
-    // Re-register the shortcut
     try {
-      const platformDefault = getPlatformDefault();
-      if (await isRegistered(platformDefault)) {
-        await unregister(platformDefault);
-      }
-      if (await isRegistered(shortcut)) {
-        await unregister(shortcut);
-      }
-
-      if (shortcutEnabled) {
-        await register(shortcut, (event) => {
-          if (event.state === "Pressed") {
-            void emit("shortcut-triggered");
-          }
-        });
-      }
+      await applyGlobalShortcut(shortcut, shortcutEnabled);
     } catch (error) {
       console.error("Failed to register shortcut:", error);
     }

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -7,6 +7,10 @@ import { load } from "@tauri-apps/plugin-store";
 import { error } from "@tauri-apps/plugin-log";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
 import icon from "../assets/icon.png";
+import {
+  estimatedStartupProgress,
+  type StartupStage,
+} from "../utils/startupProgress";
 
 export default function Splash() {
   const [status, setStatus] = useState("Initializing...");
@@ -14,6 +18,8 @@ export default function Splash() {
   const [logPath, setLogPath] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [appVersion, setAppVersion] = useState<string | null>(null);
+  const [startupStage, setStartupStage] = useState<StartupStage>("starting");
+  const [startupElapsedMs, setStartupElapsedMs] = useState(0);
 
   // Read the version from the packaged app metadata so this always reflects
   // the build the user actually launched.
@@ -30,6 +36,15 @@ export default function Splash() {
       active = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (startupStage === "ready" || startupStage === "error") return;
+    const startedAt = Date.now() - startupElapsedMs;
+    const timer = window.setInterval(() => {
+      setStartupElapsedMs(Date.now() - startedAt);
+    }, 250);
+    return () => window.clearInterval(timer);
+  }, [startupStage]);
 
   // Animated dots for loading states
   useEffect(() => {
@@ -62,6 +77,7 @@ export default function Splash() {
     const onReady = () => {
       if (readyHandled || !active) return;
       readyHandled = true;
+      setStartupStage("ready");
       setStatus("Ready!");
       setTimeout(() => { if (active) handleReady(); }, 1800);
     };
@@ -74,8 +90,16 @@ export default function Splash() {
       if (s === "ready") {
         onReady();
       } else if (s === "starting") {
+        setStartupStage("starting");
         setStatus("Starting TTS Engine");
+      } else if (s === "loading-model") {
+        setStartupStage("loading-model");
+        setStatus("Loading Speech Model");
+      } else if (s === "warming-engine") {
+        setStartupStage("warming-engine");
+        setStatus("Warming Up Voice");
       } else if (s.startsWith("error")) {
+        setStartupStage("error");
         setStatus("Engine Error");
         handleEngineError();
       }
@@ -85,6 +109,7 @@ export default function Splash() {
     invoke("start_sidecar").catch((e) => {
       console.error("[Splash] Failed to start sidecar:", e);
       if (active) {
+        setStartupStage("error");
         setStatus("Engine Error");
         handleEngineError();
       }
@@ -99,6 +124,7 @@ export default function Splash() {
           clearInterval(pollInterval);
           onReady();
         } else if (s === "starting") {
+          setStartupStage("starting");
           setStatus("Starting TTS Engine");
         }
       });
@@ -165,6 +191,7 @@ export default function Splash() {
   };
 
   const isError = status.includes("Error");
+  const startupProgress = estimatedStartupProgress(startupStage, startupElapsedMs);
 
   return (
     <div className="window-wrapper" data-tauri-drag-region>
@@ -225,6 +252,26 @@ export default function Splash() {
           >
             {status}{status.includes("Ready") || isError ? "" : dots}
           </div>
+
+          {!isError && (
+            <div className="mx-auto mt-1.5 w-44" aria-label="TTS engine startup progress">
+              <div className="h-1 overflow-hidden rounded-full bg-white/[0.06]" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={startupProgress}>
+                <div
+                  className={`h-full rounded-full transition-[width] duration-500 ${startupStage === "ready" ? "bg-emerald-400" : "bg-[#8AB4F8]"}`}
+                  style={{ width: `${startupProgress}%` }}
+                />
+              </div>
+              <p className="mt-1.5 min-h-3 text-[9px] leading-3 text-white/25" data-tauri-drag-region>
+                {startupStage === "starting" && startupElapsedMs >= 10_000
+                  ? `Preparing the offline engine · ${Math.floor(startupElapsedMs / 1_000)}s`
+                  : startupStage === "loading-model"
+                    ? "The engine is unpacked; loading its local model."
+                    : startupStage === "warming-engine"
+                      ? "Almost ready."
+                      : ""}
+              </p>
+            </div>
+          )}
 
           {/* Engine Error log info */}
           {isError && logPath && (

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow, getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
@@ -12,6 +13,23 @@ export default function Splash() {
   const [dots, setDots] = useState("");
   const [logPath, setLogPath] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  // Read the version from the packaged app metadata so this always reflects
+  // the build the user actually launched.
+  useEffect(() => {
+    let active = true;
+    getVersion()
+      .then((version) => {
+        if (active) setAppVersion(version);
+      })
+      .catch(() => {
+        // Version text is helpful but must never block engine startup.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // Animated dots for loading states
   useEffect(() => {
@@ -191,6 +209,12 @@ export default function Splash() {
           <h1 className="text-2xl font-bold text-white mb-2 tracking-tight" data-tauri-drag-region>
             Kokoro TTS
           </h1>
+          <p
+            className="min-h-[0.875rem] mb-2 text-[10px] font-semibold tracking-[0.16em] text-white/25"
+            data-tauri-drag-region
+          >
+            {appVersion ? `v${appVersion}` : ""}
+          </p>
           <div 
             key={status}
             className={`

--- a/src/utils/speechPlanner.test.ts
+++ b/src/utils/speechPlanner.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_SPEECH_SEGMENT_CHARS,
   normalizeCodeForSpeech,
   planTextForTTS,
+  replayPlanFromSegment,
 } from "./speechPlanner";
 
 describe("speech planner", () => {
@@ -163,5 +164,18 @@ describe("speech planner", () => {
 
   it("returns no segments for empty input", () => {
     expect(planTextForTTS(" \n\n ")).toEqual([]);
+  });
+});
+
+describe("sentence replay planning", () => {
+  const plan = planTextForTTS("First sentence. Second sentence. Third sentence.");
+
+  it("restarts at the active sentence and preserves everything after it", () => {
+    expect(replayPlanFromSegment(plan, plan[1].id)).toEqual(plan.slice(1));
+  });
+
+  it("falls back to the full plan when no current sentence is known", () => {
+    expect(replayPlanFromSegment(plan, null)).toBe(plan);
+    expect(replayPlanFromSegment(plan, "stale-segment")).toBe(plan);
   });
 });

--- a/src/utils/speechPlanner.test.ts
+++ b/src/utils/speechPlanner.test.ts
@@ -120,6 +120,14 @@ describe("speech planner", () => {
       .toBe(input);
   });
 
+  it("keeps segments bounded after pronunciation expansions", () => {
+    const segments = planTextForTTS(`${Array(36).fill("AI").join(" ")}.`);
+
+    expect(segments.length).toBeGreaterThan(1);
+    expect(segments.every((segment) => segment.spokenText.length <= MAX_SPEECH_SEGMENT_CHARS))
+      .toBe(true);
+  });
+
   it("uses sentence pauses internally and a paragraph pause at the block end", () => {
     const segments = planTextForTTS("First sentence. Second sentence? Third sentence!");
 
@@ -136,7 +144,7 @@ describe("speech planner", () => {
 
     expect(segments.map((segment) => segment.spokenText)).toEqual([
       "Okay..",
-      "Try v0.7.0 when it is ready.",
+      "Try version 0 point 7 point 0 when it is ready.",
     ]);
     expect(segments[0].pauseAfterMs).toBe(320);
   });
@@ -152,13 +160,53 @@ describe("speech planner", () => {
     ]);
   });
 
+  it("handles broader conversational shorthand and uppercase initialisms", () => {
+    const segments = planTextForTTS(
+      "FYI, the API is ready ASAP. btw, the US team shared a URL with us.",
+    );
+
+    expect(segments.map((segment) => segment.spokenText)).toEqual([
+      "F Y I, the A P I is ready A S A P.",
+      "B T W, the U S team shared a U R L with us.",
+    ]);
+  });
+
+  it("reads common numeric formats as deliberate speech", () => {
+    const segments = planTextForTTS(
+      "On 2026-07-25 at 3:05 p.m., upgrade from v0.6.3 to v0.7.0. It costs $12.50 at 0.5x, or 59.9% less.",
+    );
+
+    expect(segments.map((segment) => segment.spokenText)).toEqual([
+      "On July 25, 2026 at 3 oh 5 P M, upgrade from version 0 point 6 point 3 to version 0 point 7 point 0.",
+      "It costs 12 dollars and 50 cents at 0 point 5 times, or 59 point 9 percent less.",
+    ]);
+  });
+
+  it("makes links, email addresses, paths, and inline code concise but intelligible", () => {
+    const segments = planTextForTTS(
+      "Open https://example.com/docs, email support@example.com, inspect /Users/me/app.ts, then call `stream.start()`.",
+    );
+
+    expect(segments.map((segment) => segment.spokenText).join(" ")).toBe(
+      "Open example dot com slash docs, email support at example dot com, inspect path Users slash me slash app dot T S, then call stream dot start.",
+    );
+  });
+
+  it("adds a modest thought pause when a retained line break separates sentences", () => {
+    const segments = planTextForTTS(
+      "The first thought is complete.\nThe next thought begins on its own line.",
+    );
+
+    expect(segments.map((segment) => segment.pauseAfterMs)).toEqual([260, 420]);
+  });
+
   it("removes inline markup while preserving meaningful text", () => {
     const segments = planTextForTTS(
       "Read **important** [documentation](https://example.com) and `request_id`.",
     );
 
     expect(segments[0].spokenText).toBe(
-      "Read important documentation and request_id.",
+      "Read important documentation and request id.",
     );
   });
 

--- a/src/utils/speechPlanner.ts
+++ b/src/utils/speechPlanner.ts
@@ -22,6 +22,15 @@ export type SpeechPlannerOptions = {
   skipCodeBlocks?: boolean;
 };
 
+export function replayPlanFromSegment(
+  speechPlan: SpeechSegment[],
+  segmentId: string | null,
+): SpeechSegment[] {
+  if (!segmentId) return speechPlan;
+  const index = speechPlan.findIndex((segment) => segment.id === segmentId);
+  return index >= 0 ? speechPlan.slice(index) : speechPlan;
+}
+
 type SourceLine = {
   text: string;
   start: number;

--- a/src/utils/speechPlanner.ts
+++ b/src/utils/speechPlanner.ts
@@ -57,11 +57,50 @@ const FINAL_PAUSE_MS: Record<SpeechBlock["kind"], number> = {
 };
 
 const SPOKEN_SHORTHAND: Record<string, string> = {
+  afaik: "A F A I K",
+  asap: "A S A P",
+  brb: "B R B",
+  btw: "B T W",
+  fyi: "F Y I",
   idk: "I D K",
+  iirc: "I I R C",
   imo: "I M O",
+  irl: "I R L",
   lol: "L O L",
+  omg: "O M G",
   tbh: "T B H",
 };
+
+const PROSE_INITIALISMS: Record<string, string> = {
+  AI: "A I",
+  API: "A P I",
+  CPU: "C P U",
+  GPU: "G P U",
+  HTML: "H T M L",
+  HTTP: "H T T P",
+  HTTPS: "H T T P S",
+  JSON: "J son",
+  PDF: "P D F",
+  TTS: "T T S",
+  UI: "U I",
+  URL: "U R L",
+  US: "U S",
+};
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
 
 function sourceLines(input: string): SourceLine[] {
   const lines: SourceLine[] = [];
@@ -310,16 +349,94 @@ function boundRange(
   return ranges;
 }
 
+function speakDecimal(value: string): string {
+  const [whole, fraction] = value.replace(/,/g, "").split(".");
+  return fraction === undefined ? whole : `${whole} point ${fraction.split("").join(" ")}`;
+}
+
+function speakCurrency(dollars: string, cents?: string): string {
+  const amount = dollars.replace(/,/g, "");
+  const dollarUnit = amount === "1" ? "dollar" : "dollars";
+  if (!cents || Number(cents) === 0) return `${amount} ${dollarUnit}`;
+  const normalizedCents = cents.padEnd(2, "0").slice(0, 2);
+  const centUnit = normalizedCents === "01" ? "cent" : "cents";
+  return `${amount} ${dollarUnit} and ${Number(normalizedCents)} ${centUnit}`;
+}
+
+function speakTime(
+  match: string,
+  hour: string,
+  minutes: string,
+  period: string,
+  offset: number,
+  source: string,
+): string {
+  const spokenMinutes = minutes.startsWith("0") ? `oh ${Number(minutes)}` : Number(minutes);
+  const sentencePeriod = match.endsWith(".") && offset + match.length === source.length ? "." : "";
+  return `${Number(hour)} ${spokenMinutes} ${period.toUpperCase()} M${sentencePeriod}`;
+}
+
+function speakUrl(value: string): string {
+  return value
+    .replace(/^https?:\/\/(?:www\.)?/i, "")
+    .replace(/[?#].*$/, "")
+    .replace(/\./g, " dot ")
+    .replace(/\//g, " slash ")
+    .replace(/[-_]+/g, " ");
+}
+
+function speakEmail(value: string): string {
+  return value
+    .replace("@", " at ")
+    .replace(/\./g, " dot ")
+    .replace(/[_-]+/g, " ");
+}
+
+function speakPath(value: string): string {
+  return `path ${value
+    .replace(/^\/+/, "")
+    .replace(/\.([A-Za-z]{1,5})\b/g, (_match, extension: string) => (
+      ` dot ${extension.toUpperCase().split("").join(" ")}`
+    ))
+    .replace(/\//g, " slash ")
+    .replace(/[_-]+/g, " ")}`;
+}
+
 function normalizeInlineMarkup(text: string): string {
   return text
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
     .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
-    .replace(/`([^`]*)`/g, "$1")
+    .replace(/`([^`]*)`/g, (_match, code: string) => normalizeCodeForSpeech(code))
     .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, "$2")
     .replace(/~~(.*?)~~/g, "$1")
     .replace(/<[^>]*>/g, "")
+    .replace(/\bhttps?:\/\/[^\s<>()]*[A-Za-z0-9/#]/gi, speakUrl)
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, speakEmail)
+    .replace(/\/(?:Users|home|var|tmp|etc)\/[A-Za-z0-9._~/-]*[A-Za-z0-9_~-]/g, speakPath)
+    .replace(/\b(\d{4})-(\d{2})-(\d{2})\b/g, (_match, year: string, month: string, day: string) => {
+      const monthName = MONTH_NAMES[Number(month) - 1];
+      return monthName ? `${monthName} ${Number(day)}, ${year}` : _match;
+    })
+    .replace(/\b(\d{1,2}):(\d{2})\s*([ap])\.?m\.?(?=[\s,;:!?)]|$)/gi, speakTime)
+    .replace(/\$(\d[\d,]*)(?:\.(\d{1,2}))?/g, (_match, dollars: string, cents?: string) => (
+      speakCurrency(dollars, cents)
+    ))
+    .replace(/\bv(\d+(?:\.\d+){1,3})\b/gi, (_match, version: string) => (
+      `version ${version.split(".").join(" point ")}`
+    ))
+    .replace(/\b(\d+\.\d+)x\b/gi, (_match, multiplier: string) => (
+      `${speakDecimal(multiplier)} times`
+    ))
+    .replace(/\b(\d+(?:\.\d+)?)%/g, (_match, percentage: string) => (
+      `${speakDecimal(percentage)} percent`
+    ))
     .replace(/\bok\b/gi, "Okay")
-    .replace(/\b(?:idk|imo|lol|tbh)\b/gi, (match) => SPOKEN_SHORTHAND[match.toLowerCase()])
+    .replace(/\b(?:afaik|asap|brb|btw|fyi|idk|iirc|imo|irl|lol|omg|tbh)\b/gi, (match) => (
+      SPOKEN_SHORTHAND[match.toLowerCase()]
+    ))
+    .replace(/\b(?:AI|API|CPU|GPU|HTML|HTTPS?|JSON|PDF|TTS|UI|URL|US)\b/g, (match) => (
+      PROSE_INITIALISMS[match]
+    ))
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -464,15 +581,30 @@ function segmentsForBlock(
     const sourceStart = mapped.sourcePositions[start];
     const sourceEnd = mapped.sourcePositions[end - 1] + 1;
     const isLast = index === ranges.length - 1;
-    return [{
-      id: `segment-${firstId + index}`,
-      sourceText: input.slice(sourceStart, sourceEnd),
-      spokenText,
-      kind: ranges.length > 1 && !isLast ? "sentence" : block.kind,
-      pauseAfterMs: isLast ? FINAL_PAUSE_MS[block.kind] : internalPauseMs(spokenText),
-      sourceStart,
-      sourceEnd,
-    } satisfies SpeechSegment];
+    const nextSourceStart = isLast
+      ? sourceEnd
+      : mapped.sourcePositions[ranges[index + 1][0]];
+    const retainedLineBreak = /[\r\n]/.test(input.slice(sourceEnd, nextSourceStart));
+    const spokenRanges = boundRange(spokenText, 0, spokenText.length, MAX_SPEECH_SEGMENT_CHARS);
+    return spokenRanges.map(([spokenStart, spokenEnd], spokenIndex) => {
+      const finishesSourceRange = spokenIndex === spokenRanges.length - 1;
+      const finishesBlock = isLast && finishesSourceRange;
+      return {
+        id: `segment-${firstId + index + spokenIndex}`,
+        sourceText: input.slice(sourceStart, sourceEnd),
+        spokenText: spokenText.slice(spokenStart, spokenEnd),
+        kind: finishesBlock ? block.kind : "sentence",
+        pauseAfterMs: !finishesSourceRange
+          ? 80
+          : isLast
+            ? FINAL_PAUSE_MS[block.kind]
+            : retainedLineBreak
+              ? Math.max(260, internalPauseMs(spokenText))
+              : internalPauseMs(spokenText),
+        sourceStart,
+        sourceEnd,
+      } satisfies SpeechSegment;
+    });
   });
 }
 

--- a/src/utils/startupProgress.test.ts
+++ b/src/utils/startupProgress.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { estimatedStartupProgress } from "./startupProgress";
+
+describe("startup progress", () => {
+  it("advances gradually while the frozen engine is preparing", () => {
+    expect(estimatedStartupProgress("starting", 0)).toBe(8);
+    expect(estimatedStartupProgress("starting", 30_000)).toBe(38);
+    expect(estimatedStartupProgress("starting", 120_000)).toBe(72);
+  });
+
+  it("uses real engine milestones for the final steps", () => {
+    expect(estimatedStartupProgress("loading-model", 1)).toBe(82);
+    expect(estimatedStartupProgress("warming-engine", 1)).toBe(92);
+    expect(estimatedStartupProgress("ready", 1)).toBe(100);
+    expect(estimatedStartupProgress("error", 1)).toBe(100);
+  });
+});

--- a/src/utils/startupProgress.ts
+++ b/src/utils/startupProgress.ts
@@ -1,0 +1,18 @@
+export type StartupStage = "starting" | "loading-model" | "warming-engine" | "ready" | "error";
+
+export function estimatedStartupProgress(stage: StartupStage, elapsedMs: number): number {
+  switch (stage) {
+    case "loading-model":
+      return 82;
+    case "warming-engine":
+      return 92;
+    case "ready":
+    case "error":
+      return 100;
+    case "starting":
+    default:
+      // Extraction has no native progress signal. Move gradually toward a cap
+      // and wait for real model milestones rather than promising a false ETA.
+      return Math.min(72, 8 + Math.max(0, elapsedMs) / 1_000);
+  }
+}

--- a/src/utils/updateProgress.test.ts
+++ b/src/utils/updateProgress.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_UPDATE_PROGRESS,
+  updateDownloadProgress,
+} from "./updateProgress";
+
+describe("updater download progress", () => {
+  it("calculates bounded percentage from streamed chunks", () => {
+    const started = updateDownloadProgress(EMPTY_UPDATE_PROGRESS, {
+      event: "Started",
+      data: { contentLength: 1_000 },
+    });
+    const halfway = updateDownloadProgress(started, {
+      event: "Progress",
+      data: { chunkLength: 505 },
+    });
+    const finished = updateDownloadProgress(halfway, {
+      event: "Finished",
+    });
+
+    expect(started.percent).toBe(0);
+    expect(halfway).toEqual({
+      downloadedBytes: 505,
+      totalBytes: 1_000,
+      percent: 51,
+    });
+    expect(finished.percent).toBe(100);
+  });
+
+  it("reports byte progress when the server omits content length", () => {
+    const started = updateDownloadProgress(EMPTY_UPDATE_PROGRESS, {
+      event: "Started",
+      data: {},
+    });
+    const progressed = updateDownloadProgress(started, {
+      event: "Progress",
+      data: { chunkLength: 256 },
+    });
+
+    expect(progressed).toEqual({
+      downloadedBytes: 256,
+      totalBytes: null,
+      percent: null,
+    });
+  });
+});

--- a/src/utils/updateProgress.ts
+++ b/src/utils/updateProgress.ts
@@ -1,0 +1,43 @@
+import type { DownloadEvent } from "@tauri-apps/plugin-updater";
+
+export type UpdateDownloadProgress = {
+  downloadedBytes: number;
+  totalBytes: number | null;
+  percent: number | null;
+};
+
+export const EMPTY_UPDATE_PROGRESS: UpdateDownloadProgress = {
+  downloadedBytes: 0,
+  totalBytes: null,
+  percent: null,
+};
+
+export function updateDownloadProgress(
+  current: UpdateDownloadProgress,
+  event: DownloadEvent,
+): UpdateDownloadProgress {
+  if (event.event === "Started") {
+    const totalBytes = event.data.contentLength ?? null;
+    return {
+      downloadedBytes: 0,
+      totalBytes,
+      percent: totalBytes && totalBytes > 0 ? 0 : null,
+    };
+  }
+
+  if (event.event === "Progress") {
+    const downloadedBytes = current.downloadedBytes + event.data.chunkLength;
+    return {
+      ...current,
+      downloadedBytes,
+      percent: current.totalBytes && current.totalBytes > 0
+        ? Math.min(100, Math.round((downloadedBytes / current.totalBytes) * 100))
+        : null,
+    };
+  }
+
+  return {
+    ...current,
+    percent: current.totalBytes ? 100 : current.percent,
+  };
+}

--- a/tests/fixtures/reader_quality_v1.json
+++ b/tests/fixtures/reader_quality_v1.json
@@ -90,6 +90,7 @@
       "category": "numbers",
       "priority": "critical",
       "input": "The total increased from $12.50 to $19.99, or about 59.9%.",
+      "expectedSpokenSegments": ["The total increased from 12 dollars and 50 cents to 19 dollars and 99 cents, or about 59 point 9 percent."],
       "concerns": ["currency", "decimal", "percentage"]
     },
     {
@@ -97,6 +98,7 @@
       "category": "numbers",
       "priority": "critical",
       "input": "The meeting is on 2026-07-25 at 3:05 p.m.",
+      "expectedSpokenSegments": ["The meeting is on July 25, 2026 at 3 oh 5 P M."],
       "concerns": ["iso-date", "time", "abbreviation"]
     },
     {
@@ -104,6 +106,7 @@
       "category": "numbers",
       "priority": "high",
       "input": "Upgrade from v0.6.3 to v0.7.0, then test speeds from 0.5x to 2.0x.",
+      "expectedSpokenSegments": ["Upgrade from version 0 point 6 point 3 to version 0 point 7 point 0, then test speeds from 0 point 5 times to 2 point 0 times."],
       "concerns": ["semantic-version", "decimal", "range", "multiplier"]
     },
     {
@@ -118,6 +121,7 @@
       "category": "technical",
       "priority": "critical",
       "input": "Open https://example.com/docs, email support@example.com, or inspect /Users/me/project/app.ts.",
+      "expectedSpokenSegments": ["Open example dot com slash docs, email support at example dot com, or inspect path Users slash me slash project slash app dot T S."],
       "concerns": ["url-policy", "email-policy", "filesystem-path"]
     },
     {


### PR DESCRIPTION
## What changed

- adds replay-current-sentence without a forward-skip control
- previews the selected voice and volume in Settings
- improves speech planning for retained line breaks, chat shorthand, technical initialisms, dates, times, money, percentages, versions, links, email addresses, paths, and inline code
- forces Kokoro into evaluation mode to remove training-time inference variability
- adds startup milestones, version display, and better wait feedback
- bootstraps signed in-app updates with download/install/restart progress
- restores customized global shortcuts on every launch
- trims unused frozen modules while retaining the compact fully offline package
- updates the roadmap to target v1.0 hardening directly after v0.8

## Why

The largest remaining user-facing problems were controllability, inconsistent prosody, flattened document structure, awkward technical text, and unclear startup/update behavior. These changes improve Kokoro's text planning and product polish without taking on a much larger experimental engine package.

A pre-extracted runtime approached 1 GB installed and was rejected. The release remains approximately 500 MB on Apple Silicon and fully local.

## User impact

v0.8 should sound more deliberate, make long readings easier to control, and provide clearer feedback. v0.7.1 users need one manual install because that release predates the signed update channel; v0.8.1 will be the first end-to-end updater verification.

## Important fixes

- Kokoro's preloaded model was not explicitly placed in evaluation mode, leaving training-time dropout active during synthesis.
- Saved custom shortcuts were persisted but not re-registered on a fresh app launch.

## Validation

- 61 frontend tests
- 25 sidecar tests
- 13 build-script tests
- 3 Rust tests
- production frontend build
- live macOS development startup through model prewarm and healthy sidecar
- frozen Apple Silicon sidecar health and real TTS smoke test completed during packaging audit
