### PR TITLE
v0.8.1: verify signed in-app updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,3 +241,56 @@ jobs:
           updaterJsonPreferNsis: true
           releaseAssetNamePattern: "[name]_[version]_[platform]_[arch][setup].[ext]"
           args: ${{ startsWith(matrix.platform, 'macos-') && format('--target {0}', matrix.target) || '' }}
+
+  verify-updater-release:
+    name: Verify signed updater release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verify updater assets and platform metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t assets < <(
+            gh release view "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets \
+              --jq '.assets[].name'
+          )
+          printf '%s\n' "${assets[@]}"
+
+          printf '%s\n' "${assets[@]}" | grep --quiet --line-regexp 'latest.json'
+
+          signature_count="$({ printf '%s\n' "${assets[@]}" | grep --count '\.sig$'; } || true)"
+          test "$signature_count" -ge 3
+
+          temp_dir="$(mktemp -d)"
+          trap 'rm -rf "$temp_dir"' EXIT
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern latest.json \
+            --dir "$temp_dir"
+
+          expected_version="${RELEASE_TAG#v}"
+          jq --exit-status --arg version "$expected_version" \
+            '.version == $version' \
+            "$temp_dir/latest.json"
+          jq --exit-status '
+            [
+              "darwin-aarch64",
+              "darwin-x86_64",
+              "windows-x86_64"
+            ] as $required
+            | . as $release
+            | all($required[]; (
+                $release.platforms[.].url | type == "string" and length > 0
+              ) and (
+                $release.platforms[.].signature | type == "string" and length > 0
+              ))
+          ' "$temp_dir/latest.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.1 — 2026-07-28
+
+### Fixed
+
+- Generate and sign the platform-specific updater bundles required by Tauri's in-app updater.
+- Fail the release workflow if updater signatures or any macOS/Windows entry in `latest.json` are missing.
+
+### Verification release
+
+This patch is intentionally small so an installed v0.8.0 build can verify the full signed download, install, and restart path before updater support is considered production-ready.
+
 ## 0.8.0 — 2026-07-27
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arboard",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.8.0"
+version = "0.8.1"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -70,6 +70,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary

- enable Tauri updater artifact generation
- fail releases missing latest.json, signatures, or any supported platform
- bump the app to 0.8.1 as the focused updater verification patch

## Why

The v0.8.0 release workflow had valid signing secrets and requested updater metadata, but Tauri's createUpdaterArtifacts setting defaults to false. The completed logs therefore skipped latest.json and signature upload. This patch closes that gap and makes future releases fail loudly if it regresses.

## Validation

- 61 frontend tests
- production frontend build
- 3 Rust tests
- 22 dependency-free Python tests
- Tauri config load
- JSON/YAML and diff validation

After release, the installed v0.8.0 Apple Silicon build will be used to verify signed download, install, and restart end to end.