### PR TITLE
Restore widget close control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.8.2 — 2026-07-28
+
+### Fixed
+
+- Restore the floating widget's visible close button after the Replay control widened the toolbar.
+- Keep Control+Option+R as the explicit first-run and Reset default on macOS.
+- Add a layout regression test that budgets enough native-window width for every widget control and its shadow padding.
+
 ## 0.8.1 — 2026-07-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arboard",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.8.1"
+version = "0.8.2"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -200,7 +200,7 @@ async fn ensure_reader_visible(app: AppHandle) -> Result<(), String> {
             // Move to cursor and show
             if let Ok(cursor_pos) = app.cursor_position() {
                 let size = win.inner_size().unwrap_or(tauri::PhysicalSize {
-                    width: 320,
+                    width: 380,
                     height: 140,
                 });
                 let x = (cursor_pos.x - (size.width as f64 / 2.0)) as i32;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -16,7 +16,7 @@
         "label": "reader",
         "title": "Reader",
         "url": "/",
-        "width": 320,
+        "width": 380,
         "height": 140,
         "decorations": false,
         "transparent": true,

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -17,6 +17,7 @@ import {
   updateDownloadProgress,
   type UpdateDownloadProgress,
 } from "../utils/updateProgress";
+import { getPlatformDefaultShortcut } from "../utils/shortcuts";
 
 // ─── Kokoro voice presets ──────────────────────────────────────────────────
 const VOICE_PRESETS = [
@@ -28,21 +29,13 @@ const VOICE_PRESETS = [
 ] as const;
 
 const DEFAULT_VOICE = "am_fenrir";
-const DEFAULT_SHORTCUT_WIN = "Super+Shift+Q";
-const DEFAULT_SHORTCUT_MAC = "Control+Option+R";
 const VOICE_PREVIEW_TEXT = "Okay, this is how I'll sound while reading for you.";
 
 type VoicePreviewState = "idle" | "preparing" | "playing";
 type UpdaterState = "idle" | "checking" | "current" | "available" | "downloading" | "ready" | "error";
 
-function getPlatformDefault() {
-  return navigator.userAgent.includes("Mac")
-    ? DEFAULT_SHORTCUT_MAC
-    : DEFAULT_SHORTCUT_WIN;
-}
-
 async function applyGlobalShortcut(shortcut: string, enabled: boolean) {
-  const platformDefault = getPlatformDefault();
+  const platformDefault = getPlatformDefaultShortcut();
   if (await isRegistered(platformDefault)) {
     await unregister(platformDefault);
   }
@@ -61,7 +54,7 @@ async function applyGlobalShortcut(shortcut: string, enabled: boolean) {
 
 export default function SettingsWindow() {
   const [voice, setVoice] = useState(DEFAULT_VOICE);
-  const [shortcut, setShortcut] = useState(getPlatformDefault());
+  const [shortcut, setShortcut] = useState(getPlatformDefaultShortcut());
   const [shortcutEnabled, setShortcutEnabled] = useState(true);
   const [recording, setRecording] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -119,7 +112,7 @@ export default function SettingsWindow() {
       if (v) setVoice(v);
       const s = await store.get<string>("shortcut");
       const e = await store.get<boolean>("shortcut-enabled");
-      const savedShortcut = s || getPlatformDefault();
+      const savedShortcut = s || getPlatformDefaultShortcut();
       const savedShortcutEnabled = e ?? true;
       setShortcut(savedShortcut);
       setShortcutEnabled(savedShortcutEnabled);
@@ -465,7 +458,7 @@ export default function SettingsWindow() {
             </div>
             <button
               onClick={() => {
-                setShortcut(getPlatformDefault());
+                setShortcut(getPlatformDefaultShortcut());
                 setRecording(false);
               }}
               className="px-4 py-2.5 rounded-xl text-xs font-semibold bg-white/5 border border-white/10 hover:bg-white/10 transition-smooth text-white/60 hover:text-white/90"

--- a/src/utils/shortcuts.test.ts
+++ b/src/utils/shortcuts.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SHORTCUT_MAC,
+  DEFAULT_SHORTCUT_WIN,
+  getPlatformDefaultShortcut,
+} from "./shortcuts";
+
+describe("platform shortcut defaults", () => {
+  it("uses Control+Option+R on macOS", () => {
+    expect(getPlatformDefaultShortcut("Mozilla/5.0 (Macintosh; Intel Mac OS X)"))
+      .toBe("Control+Option+R");
+    expect(DEFAULT_SHORTCUT_MAC).toBe("Control+Option+R");
+  });
+
+  it("keeps the Windows default distinct", () => {
+    expect(getPlatformDefaultShortcut("Mozilla/5.0 (Windows NT 10.0; Win64; x64)"))
+      .toBe("Super+Shift+Q");
+    expect(DEFAULT_SHORTCUT_WIN).toBe("Super+Shift+Q");
+  });
+});

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_SHORTCUT_MAC = "Control+Option+R";
+export const DEFAULT_SHORTCUT_WIN = "Super+Shift+Q";
+
+export function getPlatformDefaultShortcut(
+  userAgent: string = navigator.userAgent,
+): string {
+  return userAgent.includes("Mac")
+    ? DEFAULT_SHORTCUT_MAC
+    : DEFAULT_SHORTCUT_WIN;
+}

--- a/src/utils/widgetLayout.test.ts
+++ b/src/utils/widgetLayout.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import tauriConfig from "../../src-tauri/tauri.conf.json";
+
+describe("floating widget native window", () => {
+  it("keeps every control, including Close, inside the visible viewport", () => {
+    const reader = tauriConfig.app.windows.find((window) => window.label === "reader");
+    const controlWidths = [36, 28, 28, 72, 36, 28];
+    const controlGaps = (controlWidths.length - 1) * 6;
+    const containerPadding = 16;
+    const shadowPadding = 80;
+    const minimumWidth = controlWidths.reduce((sum, width) => sum + width, 0)
+      + controlGaps
+      + containerPadding
+      + shadowPadding;
+
+    expect(reader?.width).toBeGreaterThanOrEqual(minimumWidth);
+    expect(reader?.shadow).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- widen the native reader window so Replay and Close both remain visible
- keep Control+Option+R as the explicit macOS default and Reset value
- add shortcut and native-window layout regression coverage
- bump the patch release to 0.8.2

## Verification
- 64 frontend tests pass
- production frontend build passes
- 3 Rust tests pass
- 22 dependency-free Python tests pass
- native macOS QA confirmed Control+Option+R opens the reader and the restored X hides it immediately
- installed v0.8.1 remains healthy, ready for the real updater-hop test