### PR TITLE
Release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.8.3 — 2026-07-30
+
+### Changed
+
+- Use a dedicated monochrome Shiba template icon in the macOS menu bar while retaining the full-color application icon.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokoro-clipboard-tts",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokoro-clipboard-tts",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro-clipboard-tts",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kokoro-clipboard-tts"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "arboard",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kokoro-clipboard-tts"
-version = "0.8.2"
+version = "0.8.3"
 description = "Clipboard TTS powered by Kokoro-82M"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kokoro-clipboard-tts",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "identifier": "com.kokoro.clipboard-tts",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- version the merged Windows reader-frame fix as 0.8.3
- include the dedicated monochrome macOS menu-bar icon merged after 0.8.2
- preserve the otherwise known-good 0.8.2 application behavior
- publish through the existing signed cross-platform updater workflow after merge/tag

## Validation

- 64 frontend tests pass
- production frontend build passes
- 4 Rust tests pass locally
- 25 sidecar tests pass in the project runtime
- 13 release/script tests pass
- Windows, Apple Silicon, and Intel CI already passed for the functional frame fix in PR #30

Closes #29