### PR TITLE
Add a durable issue-to-release workflow

### DIFF
--- a/.agent/CONTRIBUTING.md
+++ b/.agent/CONTRIBUTING.md
@@ -1,50 +1,66 @@
-# Contributing to Kokoro-Clipboard-TTS
+# Contributing to Kokoro Clipboard TTS
 
-Thank you for your interest in contributing! This document contains the necessary information for setting up your development environment, understanding the CI/CD pipeline, and building the standalone Kokoro TTS sidecar if you are working on the AI engine.
+This is the human-facing path from a GitHub issue to a tested, signed release.
+Agents should additionally follow `.codex/skills/kokoro-issue-to-release/SKILL.md`.
 
-## 🛠 Development Setup
+## Development setup
 
-### Prerequisites
-
-- **Node.js** 20+ and **npm**
-- **Rust** (stable, 1.88.0+ recommended)
-- **Python 3.10+** (for sidecar development)
-- **macOS only**: `brew install portaudio libsndfile`
-
-### Clone & Install
+Prerequisites: Node.js 20+, stable Rust, Python 3.10+, and on macOS
+`brew install portaudio libsndfile`.
 
 ```bash
-git clone https://github.com/seanbud/Kokoro-Clipboard-TTS.git
-cd Kokoro-Clipboard-TTS
-npm install
-```
-
-### Run in Development
-
-```bash
-# 1. Build the sidecar once for your platform
-# This script automatically detects your OS/Architecture and builds the sidecar into src-tauri/binaries/
-python3 scripts/build_local_sidecar.py
-
-# 2. Run Tauri dev
+npm ci
+python3 -m venv .sidecar-venv
+source .sidecar-venv/bin/activate       # Windows: .sidecar-venv\Scripts\activate
+pip install -r requirements.txt
+python -m spacy download en_core_web_sm
+python scripts/build_local_sidecar.py
 npm run tauri dev
 ```
 
----
+## Issue-to-PR workflow
 
-## 🐍 CI/CD Automation
-
-The GitHub Actions workflow (`release.yml`) automatically:
-1. Sets up a Python environment.
-2. Downloads the **Kokoro-82M** ONNX model and voice weights.
-3. Bundles them into a standalone sidecar binary using **PyInstaller**.
-4. Packages everything into the final Tauri installer.
-
----
-
-If you are developing the sidecar script (`sidecar/kokoro_server.py`), you can use the provided build script which handles all collectors and renaming:
+1. Read the whole issue and write observable acceptance criteria.
+2. Start from updated `main` on a `codex/<issue>-<slug>` branch.
+3. Reproduce and diagnose before editing. Add a regression test when possible.
+4. Keep OS-specific changes scoped to that OS and manually inspect the affected
+   window/audio behavior. Record unavailable platform testing honestly.
+5. Run the local CI-equivalent gate:
 
 ```bash
-python3 scripts/build_local_sidecar.py
+python3 .codex/skills/kokoro-issue-to-release/scripts/verify.py
 ```
-> The file naming convention with target triples is required by Tauri's `externalBin` resolver (e.g., `kokoro-x86_64-pc-windows-msvc.exe`).
+
+6. Open a draft PR with `Fixes #<issue>`, root cause, test evidence, manual test
+   evidence, and residual risk. All Windows x64, macOS Apple Silicon, and macOS
+   Intel CI jobs must pass before merge.
+
+## Release workflow
+
+Use a separate release PR after functional work is merged.
+
+1. Update `package.json`, both root package versions in `package-lock.json`,
+   `src-tauri/Cargo.toml`, the app package in `src-tauri/Cargo.lock`,
+   `src-tauri/tauri.conf.json`, and `CHANGELOG.md`.
+2. Run both local gates (replace `X.Y.Z`):
+
+```bash
+python3 .codex/skills/kokoro-issue-to-release/scripts/release_gate.py X.Y.Z
+python3 .codex/skills/kokoro-issue-to-release/scripts/verify.py
+```
+
+3. Merge the passing release PR, update local `main`, and push an annotated
+   `vX.Y.Z` tag. The tag triggers `.github/workflows/release.yml`; do not create a
+   second manual release.
+4. After the workflow succeeds, verify the public installers and signed updater:
+
+```bash
+python3 .codex/skills/kokoro-issue-to-release/scripts/release_gate.py X.Y.Z --published
+```
+
+5. For packaging, audio, or updater changes, complete the applicable frozen
+   sidecar/install/update smoke tests in `RELEASE_TESTING.md` before announcing.
+
+The release workflow downloads the pinned Kokoro model, builds the native Sonic
+DSP and standalone Python sidecar, packages Windows and both macOS architectures,
+publishes installers plus `latest.json`, and verifies all updater signatures.

--- a/.codex/skills/kokoro-issue-to-release/SKILL.md
+++ b/.codex/skills/kokoro-issue-to-release/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: kokoro-issue-to-release
+description: Take a Kokoro Clipboard TTS GitHub issue through triage, diagnosis, implementation, cross-platform verification, pull request review, merge, and signed updater release. Use for issue fixes, feature work, PR preparation, CI failures, version releases, and post-release verification in this repository.
+---
+
+# Kokoro Issue to Release
+
+Ship one well-understood change without regressing the app's offline, responsive,
+cross-platform reader experience. Read `references/repo-map.md` before editing.
+
+## Establish scope
+
+1. Read the issue body, all comments, linked PRs, and attached media. Prefer the
+   GitHub connector; use `gh` when thread state, checks, or releases need it.
+2. Restate the user-visible failure and turn it into explicit acceptance criteria.
+   Separate facts, hypotheses, and product choices.
+3. Inspect the relevant code and history. Reproduce or create the smallest failing
+   test before changing behavior when practical.
+4. Check the working tree. Preserve unrelated changes. Start from current `main`
+   and create a focused `codex/<issue>-<slug>` branch.
+5. State any manual or unavailable platform gate early. Do not pretend local macOS
+   testing proves Windows behavior or the reverse.
+
+## Implement the smallest complete fix
+
+- Correct the root cause, not just its visible symptom.
+- Keep platform behavior isolated with Tauri/Rust target conditions or narrowly
+  scoped runtime checks. Preserve the other platform's established appearance.
+- Keep clipboard text and generated speech local. Treat new model engines as
+  removable, opt-in packs unless the issue explicitly changes that decision.
+- Add regression coverage at the lowest useful layer: Vitest for UI/planning,
+  Python unittest for the sidecar, and Rust tests for commands/window lifecycle.
+- Update user-facing docs or changelog only when behavior or release instructions
+  changed. Do not mix a version bump into a feature PR.
+- Use `apply_patch` for intentional edits and review `git diff` before testing.
+
+## Verify locally
+
+Run:
+
+```bash
+python3 .codex/skills/kokoro-issue-to-release/scripts/verify.py
+```
+
+The command mirrors CI: native Sonic build/tests, Python suites, frontend tests and
+build, Rust formatting and tests, and whitespace checks. Use `--quick` only during
+iteration; the final PR requires the full command.
+
+For visual, audio, updater, installation, or platform-specific work, also execute
+the applicable manual cases in `RELEASE_TESTING.md`. Record exactly what was and
+was not exercised in the PR.
+
+## Publish and review
+
+1. Inspect the final diff and `git status`; commit only files belonging to the issue.
+2. Push the branch and open a draft PR whose body contains:
+   - `Fixes #<number>` when merging should close the issue;
+   - the root cause and solution;
+   - automated test evidence;
+   - manual/platform test evidence and remaining risk.
+3. Monitor checks without noisy polling. If CI fails, read the failing logs, fix the
+   cause, rerun the local gate, and update the same PR.
+4. Keep visual or platform-specific PRs in draft until their manual gate is met.
+5. Resolve review feedback and require all CI matrix jobs to pass. Merge only when
+   the user has authorized shipping/merging and the acceptance criteria are met.
+
+## Release separately
+
+Functional changes merge before release plumbing. Unless the user explicitly asks
+for a release, stop after the ready PR or merge.
+
+1. Choose the smallest correct semantic version and create a release-only branch.
+2. Update every version location listed in `references/repo-map.md` and add a dated
+   `CHANGELOG.md` entry.
+3. Run the pre-tag gate and full verification:
+
+```bash
+python3 .codex/skills/kokoro-issue-to-release/scripts/release_gate.py 0.0.0
+python3 .codex/skills/kokoro-issue-to-release/scripts/verify.py
+```
+
+4. Publish, pass CI, and merge the release PR. Pull the resulting `main` commit.
+5. Create and push the annotated tag `v0.0.0`. Do not manually create a competing
+   GitHub release: `.github/workflows/release.yml` owns build and publication.
+6. Wait for the Release workflow once, using event-driven or bounded waits. Fix the
+   workflow and retag only with explicit care if it fails; never hide a failed run.
+7. Confirm the release is public (not draft), then run:
+
+```bash
+python3 .codex/skills/kokoro-issue-to-release/scripts/release_gate.py 0.0.0 --published
+```
+
+8. Smoke-test the in-app updater from the previous public version when updater code
+   or packaging changed. Only then report the release as shipped.
+
+## Stop conditions
+
+Stop and report evidence instead of widening scope when acceptance requires
+hardware or a platform unavailable to you, a license/privacy decision, signing
+secrets, destructive data changes, or a materially different product direction.

--- a/.codex/skills/kokoro-issue-to-release/agents/openai.yaml
+++ b/.codex/skills/kokoro-issue-to-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kokoro Issue to Release"
+  short_description: "Safely take a Kokoro issue from diagnosis to release"
+  default_prompt: "Use this workflow to diagnose, fix, test, review, merge, and release a Kokoro Clipboard TTS GitHub issue."

--- a/.codex/skills/kokoro-issue-to-release/references/repo-map.md
+++ b/.codex/skills/kokoro-issue-to-release/references/repo-map.md
@@ -1,0 +1,39 @@
+# Kokoro Clipboard TTS repository map
+
+## Main layers
+
+- `src/`: React UI, reader controls, text planning, startup/update presentation.
+- `src-tauri/src/`: Tauri lifecycle, windows, tray, shortcuts, updater, sidecar bridge.
+- `sidecar/`: local Kokoro generation, audio playback, live speed, protocol.
+- `scripts/`: native DSP build and benchmark/analysis tools.
+- `tests/fixtures/reader_quality_v1.json`: long-form speech-planning quality corpus.
+- `.github/workflows/ci.yml`: Windows x64, macOS Apple Silicon, macOS Intel PR gate.
+- `.github/workflows/release.yml`: tag-triggered offline model packaging, signed
+  installers, GitHub release, `latest.json`, and updater signature verification.
+
+## Version sources
+
+All must match before tagging:
+
+- `package.json`: `version`
+- `package-lock.json`: top-level `version`
+- `package-lock.json`: root package `packages[""].version`
+- `src-tauri/Cargo.toml`: package `version`
+- `src-tauri/Cargo.lock`: `kokoro-clipboard-tts` package `version`
+- `src-tauri/tauri.conf.json`: `version`
+- `CHANGELOG.md`: `## X.Y.Z — YYYY-MM-DD`
+
+`src-tauri/tauri.conf.json` must retain `bundle.createUpdaterArtifacts: true` and
+the updater public key/endpoints. A pushed `vX.Y.Z` tag is the only release trigger.
+
+## Required evidence by change type
+
+| Change | Automated evidence | Manual evidence |
+|---|---|---|
+| React/planning | Vitest regression + build | Relevant window/reader behavior |
+| Tauri/window/tray | Rust test where possible + CI matrix | Changed OS plus unchanged peer OS |
+| Sidecar/audio | Python regression + CI matrix | Playback, pause, speed, cancellation |
+| Packaging/updater | Full CI + release gate | Clean install/update from prior release |
+| Optional engine | Benchmarks, size/license audit | Opt-in UX, removal, offline behavior |
+
+Use `RELEASE_TESTING.md` for the frozen-sidecar and release smoke procedures.

--- a/.codex/skills/kokoro-issue-to-release/scripts/release_gate.py
+++ b/.codex/skills/kokoro-issue-to-release/scripts/release_gate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Validate synchronized versions and optionally the published updater release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tempfile
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+REPO = "seanbud/Kokoro-Clipboard-TTS"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"Release gate failed: {message}")
+
+
+def cargo_toml_version(path: Path) -> str:
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', path.read_text())
+    if not match:
+        fail(f"could not read version from {path.relative_to(ROOT)}")
+    return match.group(1)
+
+
+def cargo_lock_version(path: Path) -> str:
+    text = path.read_text()
+    match = re.search(
+        r'\[\[package\]\]\s*\nname = "kokoro-clipboard-tts"\s*\nversion = "([^"]+)"',
+        text,
+    )
+    if not match:
+        fail("could not read app version from src-tauri/Cargo.lock")
+    return match.group(1)
+
+
+def local_gate(version: str) -> None:
+    package = json.loads((ROOT / "package.json").read_text())
+    lock = json.loads((ROOT / "package-lock.json").read_text())
+    tauri = json.loads((ROOT / "src-tauri/tauri.conf.json").read_text())
+    actual = {
+        "package.json": package["version"],
+        "package-lock.json": lock["version"],
+        'package-lock.json packages[""]': lock["packages"][""]["version"],
+        "src-tauri/Cargo.toml": cargo_toml_version(ROOT / "src-tauri/Cargo.toml"),
+        "src-tauri/Cargo.lock": cargo_lock_version(ROOT / "src-tauri/Cargo.lock"),
+        "src-tauri/tauri.conf.json": tauri["version"],
+    }
+    mismatches = [f"{name}={value}" for name, value in actual.items() if value != version]
+    if mismatches:
+        fail("version mismatch: " + ", ".join(mismatches))
+    if tauri.get("bundle", {}).get("createUpdaterArtifacts") is not True:
+        fail("Tauri signed updater artifacts are disabled")
+    updater = tauri.get("plugins", {}).get("updater", {})
+    if not updater.get("pubkey") or not updater.get("endpoints"):
+        fail("Tauri updater public key or endpoint is missing")
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+    if not re.search(rf"(?m)^## {re.escape(version)} — \d{{4}}-\d{{2}}-\d{{2}}$", changelog):
+        fail(f"CHANGELOG.md has no dated {version} heading")
+    print(f"Local release metadata is synchronized at {version}.")
+
+
+def published_gate(version: str) -> None:
+    tag = f"v{version}"
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", REPO, "--json", "isDraft,tagName,url"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode:
+        fail(result.stderr.strip() or f"GitHub release {tag} was not found")
+    release = json.loads(result.stdout)
+    if release["isDraft"] or release["tagName"] != tag:
+        fail(f"{tag} is missing or still a draft")
+
+    url = f"https://github.com/{REPO}/releases/download/{tag}/latest.json"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            latest = json.load(response)
+    except Exception as exc:
+        fail(f"could not fetch public latest.json: {exc}")
+    if latest.get("version") != version:
+        fail(f"latest.json reports {latest.get('version')!r}, expected {version!r}")
+    required = {"darwin-aarch64", "darwin-x86_64", "windows-x86_64"}
+    platforms = latest.get("platforms", {})
+    for name in sorted(required):
+        metadata = platforms.get(name, {})
+        if not metadata.get("url") or not metadata.get("signature"):
+            fail(f"latest.json lacks signed updater metadata for {name}")
+    print(f"Published signed updater release verified: {release['url']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", help="Release version without the v prefix")
+    parser.add_argument("--published", action="store_true")
+    args = parser.parse_args()
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?", args.version):
+        fail("version must be semantic version text without a v prefix")
+    local_gate(args.version)
+    if args.published:
+        published_gate(args.version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/kokoro-issue-to-release/scripts/verify.py
+++ b/.codex/skills/kokoro-issue-to-release/scripts/verify.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Run the local Kokoro Clipboard TTS pull-request verification gate."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+def run(*command: str, cwd: Path = ROOT) -> None:
+    print(f"\n+ {' '.join(command)}", flush=True)
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def python_with_numpy() -> str:
+    candidates = [
+        ROOT / ".sidecar-venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python"),
+        Path(sys.executable),
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            result = subprocess.run(
+                [str(candidate), "-c", "import numpy"],
+                cwd=ROOT,
+                capture_output=True,
+            )
+            if result.returncode == 0:
+                return str(candidate)
+    raise SystemExit(
+        "No project Python with numpy found. Activate/install requirements in "
+        ".sidecar-venv, then rerun this gate."
+    )
+
+
+def ensure_test_sidecar() -> None:
+    machine = platform.machine().lower()
+    if sys.platform == "darwin":
+        target = "aarch64-apple-darwin" if machine in {"arm64", "aarch64"} else "x86_64-apple-darwin"
+        path = ROOT / "src-tauri" / "binaries" / f"kokoro-{target}"
+    elif os.name == "nt":
+        path = ROOT / "src-tauri" / "binaries" / "kokoro-x86_64-pc-windows-msvc.exe"
+    else:
+        path = ROOT / "src-tauri" / "binaries" / "kokoro-x86_64-unknown-linux-gnu"
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        print(f"Created ignored Rust-test sidecar placeholder: {path.relative_to(ROOT)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Skip native DSP build and production frontend build during iteration.",
+    )
+    args = parser.parse_args()
+
+    py = python_with_numpy()
+    if not args.quick:
+        run(py, "scripts/build_sonic_dsp.py")
+    run(py, "-m", "unittest", "discover", "-s", "sidecar", "-p", "test_*.py")
+    run(py, "-m", "unittest", "discover", "-s", "scripts", "-p", "test_*.py")
+
+    if not (ROOT / "node_modules").exists():
+        run("npm", "ci")
+    run("npm", "test", "--", "--run")
+    if not args.quick:
+        run("npm", "run", "build")
+
+    ensure_test_sidecar()
+    run("cargo", "fmt", "--check", cwd=ROOT / "src-tauri")
+    run("cargo", "test", cwd=ROOT / "src-tauri")
+    run("git", "diff", "--check")
+    print("\nVerification gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Repository agent guide
+
+Use the repo-local `kokoro-issue-to-release` skill for any request that starts
+from a GitHub issue or is expected to end in a pull request or release:
+
+`.codex/skills/kokoro-issue-to-release/SKILL.md`
+
+## Non-negotiable project rules
+
+- Keep Kokoro Clipboard TTS private and offline by default. Do not add telemetry,
+  cloud APIs, or network speech processing without an explicit product decision.
+- Preserve unrelated working-tree changes. Never discard user work.
+- Create focused branches with the `codex/` prefix and focused commits.
+- Diagnose before editing. Turn the issue into observable acceptance criteria and
+  add a regression test whenever the behavior can be automated.
+- Scope platform-specific UI and window changes explicitly. A Windows fix must
+  not alter macOS behavior unless the issue requires it, and vice versa.
+- Keep the bundled core installer and default Kokoro experience working when
+  experimenting with optional engines.
+- Run the repo verification script before publishing a pull request:
+  `python3 .codex/skills/kokoro-issue-to-release/scripts/verify.py`.
+- Never claim a release is shipped until the public GitHub release and signed
+  updater metadata have passed the post-release gate.
+
+Human setup and release documentation lives in `.agent/CONTRIBUTING.md`.


### PR DESCRIPTION
## What changed

- adds a repo-local `kokoro-issue-to-release` skill for issue triage, implementation, PR review, merge, and signed releases
- adds deterministic local verification and release metadata gates
- adds root agent guardrails and upgrades the human contributing guide
- documents platform-specific and optional-engine evidence requirements

## Why

The repository had working CI/CD automation but no single, current operating procedure connecting a GitHub issue to a verified public updater release. The old contributing guide also described an obsolete packaging flow.

## Validation

- repo-local skill passes `quick_validate.py`
- full local gate passes: 38 Python tests, 64 frontend tests, production frontend build, Rust formatting, and 4 Rust tests
- release gate validates synchronized v0.8.3 metadata
- published gate verifies the public v0.8.3 release and signed updater metadata for Apple Silicon macOS, Intel macOS, and Windows x64

## Risk

Documentation and tooling only. The scripts deliberately fail when required dependencies or release metadata are missing.