### PR TITLE
Benchmark Chatterbox Nano for issue 27

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,7 @@ Working release name: **Speech Intelligence**
 - W6 update/recovery: signed updater metadata, download progress, install/restart controls, startup milestones, saved-shortcut restoration, and version display are implemented. v0.8.0 bootstraps the signing channel; v0.8.1 must prove an installed update from v0.8.0.
 - W4.2 backend benchmark: corpus-driven PyTorch CPU/MPS runner and initial M2 reference suite implemented; Windows/CUDA and frozen-package measurements pending.
 - W5.3 Pocket TTS benchmark: isolated v2.1.0 CPU streaming runner and initial M2 unquantized/quantized measurements implemented; blind quality and frozen-package work pending.
+- W5.4 Chatterbox Nano benchmark: the official v0.1.7 implementation failed the Apple M2 size, first-audio, throughput, and memory gates. Keep it out of the app and revisit only after upstream provides a materially smaller streaming distribution; see `docs/investigations/chatterbox-nano-issue-27.md`.
 - Remaining W1–W6 work: active, sequenced below; engine promotion remains evidence-gated.
 
 ## Release outcome

--- a/docs/investigations/chatterbox-nano-issue-27.md
+++ b/docs/investigations/chatterbox-nano-issue-27.md
@@ -1,0 +1,153 @@
+# Chatterbox Nano engine-pack spike (issue #27)
+
+Recorded 2026-08-07. Recommendation: **do not build or offer a Chatterbox
+Nano pack from the current official v0.1.7 implementation**. It misses the
+size, responsiveness, throughput, and memory gates on the available Apple M2
+reference machine. Kokoro remains the bundled default and no Chatterbox code,
+weights, downloads, settings, or branding are added to the app.
+
+## Tested implementation
+
+- Official source: [`resemble-ai/chatterbox` at `5de7a54`](https://github.com/resemble-ai/chatterbox/commit/5de7a54aa4e5e2baadb0182dde554908b48b85c2), package 0.1.7
+- Official model: [`ResembleAI/chatterbox-nano` at `71ccd1d`](https://huggingface.co/ResembleAI/chatterbox-nano/tree/71ccd1d0081b430592cea481f4307e764e07bc64)
+- API: `ChatterboxTurboTTS.from_local(..., nano=True)` with the bundled default
+  `conds.pt` voice and upstream generation defaults
+- Machine: M2 MacBook Air, 8 CPU cores, 16 GB RAM, macOS 14.4, Python 3.10.16,
+  Torch 2.6.0
+- Corpus: the unchanged `tests/fixtures/reader_quality_v1.json` latency suite
+- Each run used one short warmup. The four-fixture pass used one measurement per
+  fixture; the short-fixture check used three repetitions to reduce warm-run noise.
+
+The benchmark tool lives at `scripts/benchmark_chatterbox_nano.py`. It is not an
+application dependency and imports Chatterbox only inside an isolated benchmark
+environment. It records fixture IDs and text shape rather than clipboard text.
+
+## Size gate
+
+The Nano label describes its 110M text-to-speech backbone, not its total shipped
+runtime. The current official loader selects every safetensors file, including a
+1,056,484,620-byte `s3gen.safetensors` file that Nano does not load.
+
+| Artifact | Bytes | Approximate size |
+|---|---:|---:|
+| Official loader's selected Nano snapshot | 2,998,584,368 | 2.79 GiB |
+| Assets actually loaded by Nano | 1,942,099,748 | 1.81 GiB |
+| Isolated installed Python environment used by this spike | 1,299,015,473 | 1.21 GiB |
+| Current bundled Kokoro model directory | 355,486,216 | 339 MiB |
+| Current v0.8.3 Apple Silicon DMG | 565,275,849 | 539 MiB |
+
+Even a corrected minimal Nano download would contain about 5.5 times the current
+Kokoro model bytes before packaging Nano's runtime. The measured benchmark
+environment plus official snapshot occupied about 4.0 GiB. A production frozen
+pack may compress differently, but this is already enough to fail the pack-size
+gate without spending release effort on a PyInstaller prototype.
+
+## Performance gate
+
+The official `generate()` method returns one complete waveform tensor. It does
+not expose an audio iterator or callback, so its generation time is also the
+earliest possible first audio without maintaining a non-upstream streaming fork.
+
+### Repeated warm short fixture
+
+`chat-ok-ellipsis` (62 characters, 14 words), three repetitions:
+
+| Engine/device | Ready time | Median first audio | Median RTF | Peak RSS |
+|---|---:|---:|---:|---:|
+| Nano CPU | 10.31 s | 13.02 s | 3.420 | 4.36 GB |
+| Nano MPS | 10.82 s | 10.50 s | 2.915 | 3.68 GB |
+| Kokoro CPU | 2.75 s | 1.46 s | 0.356 | not collected by baseline runner |
+| Kokoro MPS | 2.84 s | 1.09 s | 0.265 | not collected by baseline runner |
+
+On MPS, Nano's median audio became available about 9.7 times later than Kokoro's.
+An RTF above 1 means synthesis is slower than the produced audio; Nano measured
+about 2.9–3.4 times slower than real time after warmup. This machine therefore
+did not reproduce the model card's general “3x faster than realtime on 8 cores”
+CPU claim under the official macOS build and this narration fixture.
+
+### Four-fixture latency suite
+
+| Engine/device | Success | Median first audio | p95 | Median RTF | Long-form result |
+|---|---:|---:|---:|---:|---|
+| Nano CPU | 4/4 | 19.78 s | 37.30 s | 3.427 | 37.30 s for 12.08 s audio |
+| Nano MPS | 3/4 | 14.81 s | 16.69 s | 3.567 | failed |
+| Kokoro CPU | 4/4 | 3.76 s | 11.72 s | 0.791 | 11.72 s for 14.10 s audio |
+| Kokoro MPS | 3/4 | 2.25 s | 2.29 s | 0.557 | failed |
+
+The unbounded 229-character sentence failed on MPS for both engines with
+`NotImplementedError: Output channels > 65536 not supported at the MPS device`.
+That shared raw-input limitation is why the production planner bounds Kokoro
+segments; it also means an MPS Nano pack cannot be advertised as compatible
+without the same segmentation and frozen-app validation. CPU Nano completed the
+sentence but did not expose any audio during its 37.30-second generation call.
+
+## App-control compatibility
+
+| Capability | Current official Nano behavior | Product implication |
+|---|---|---|
+| Streaming / early playback | No streaming output | Cannot preserve current overlap or first-audio behavior as-is |
+| Cancel generation | Synchronous call has no cancellation hook | Would require killing a worker or maintaining upstream changes |
+| Pause/resume | Possible only after audio has been returned to the app | Existing sample-accurate player can handle completed audio |
+| Live speed | Compatible downstream through the existing Sonic player | Does not reduce Nano generation wait |
+| Long-form structure | Upstream normalization collapses whitespace | The app planner must continue owning segments and external pauses |
+| Acronyms/numbers/code | No deterministic product-specific normalization | Existing planner rules remain necessary regardless of engine |
+
+Splitting every sentence or clause into separate calls is not equivalent to true
+streaming: it can reduce the first request's length, but each call still has
+multi-second latency and may lose cross-clause prosody. It does not rescue the
+measured gate.
+
+## Quality, privacy, and licensing
+
+- Nano supports an included default voice and optional voice cloning. Upstream
+  requires a reference clip longer than five seconds for cloning. A future pack
+  would need explicit local storage/removal UX and must never upload reference
+  audio; this spike used only the included voice.
+- Once cached, the benchmark ran with `HF_HUB_OFFLINE=1`, confirming local
+  inference. A real optional pack would still require an explicit network model
+  download, checksums/signatures, progress, removal, and clean Kokoro fallback.
+- The upstream code and model card declare MIT; the bundled Perth watermarker is
+  also MIT. Distribution still requires a complete transitive dependency/license
+  audit and retained notices.
+- Upstream applies a Perth neural watermark to every generated file. Product UI
+  and documentation would need to disclose that behavior.
+- Paralinguistic tags such as `[laugh]` are a real expressive advantage, but they
+  do not address deterministic shorthand, number, code, or structure planning.
+- A blind, loudness-normalized listener comparison was not run. It remains a
+  required gate, but there is no reason to ask users to do that work while the
+  objective size and responsiveness gates already fail.
+
+## Reproduction
+
+Install upstream outside the app repository so the core dependency lock remains
+unchanged:
+
+```bash
+python3.10 -m venv /tmp/chatterbox-nano-bench
+/tmp/chatterbox-nano-bench/bin/pip install \
+  'git+https://github.com/resemble-ai/chatterbox.git@5de7a54aa4e5e2baadb0182dde554908b48b85c2'
+HF_HUB_DISABLE_XET=1 /tmp/chatterbox-nano-bench/bin/python \
+  scripts/benchmark_chatterbox_nano.py \
+  --device cpu --suite latency --warmup-runs 1 --repetitions 1 --pretty
+```
+
+For MPS, add `PYTORCH_ENABLE_MPS_FALLBACK=1` and use `--device mps`. The script
+pins the model revision, uses seed 27 by default, records the selected and loaded
+asset sizes, and can write listening samples only when `--audio-dir` is supplied.
+
+## Open gates and revisit trigger
+
+Intel macOS, Windows, frozen-pack packaging, signed download/removal UX, and blind
+preference tests were not run. They are intentionally not represented as passing.
+
+Do not spend those gates on v0.1.7. Revisit Nano only when an official release:
+
+1. provides real incremental streaming or a cancellable generator;
+2. makes a first chunk available near Kokoro's latency on ordinary hardware;
+3. distributes a materially smaller minimal runtime (target under 1 GB installed,
+   with the exact product budget decided before implementation); and
+4. passes the bounded long-form suite on supported CPU/accelerator paths.
+
+If those triggers occur, rerun this script on Apple Silicon, Intel Mac, and
+Windows, then perform the blind listener and frozen-package gates before adding
+any in-app engine-download UX.

--- a/scripts/benchmark_chatterbox_nano.py
+++ b/scripts/benchmark_chatterbox_nano.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Benchmark official Chatterbox Nano without adding it to app dependencies.
+
+Install the pinned upstream checkout in an isolated Python environment, then run:
+
+    python scripts/benchmark_chatterbox_nano.py --suite latency --device cpu \
+      --repetitions 1 --pretty
+
+The benchmark downloads the model revision used by this investigation and calls
+the official ``ChatterboxTurboTTS`` implementation with ``nano=True`` semantics
+through ``from_local(..., nano=True)``. Output records fixture identity and text
+shape, never source text. Audio files are only written when ``--audio-dir`` is
+provided, so routine benchmark evidence remains small and reviewable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    import resource
+except ImportError:  # Windows does not provide the Unix resource module.
+    resource = None
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS = PROJECT_ROOT / "tests" / "fixtures" / "reader_quality_v1.json"
+IMPLEMENTATION_REVISION = "5de7a54aa4e5e2baadb0182dde554908b48b85c2"
+MODEL_REPOSITORY = "ResembleAI/chatterbox-nano"
+MODEL_REVISION = "71ccd1d0081b430592cea481f4307e764e07bc64"
+OFFICIAL_DOWNLOAD_PATTERNS = ["*.safetensors", "*.json", "*.txt", "*.pt", "*.model"]
+NANO_RUNTIME_FILES = {
+    "added_tokens.json",
+    "conds.pt",
+    "merges.txt",
+    "s3gen_meanflow.safetensors",
+    "special_tokens_map.json",
+    "t3_nano_v1.safetensors",
+    "tokenizer_config.json",
+    "ve.safetensors",
+    "vocab.json",
+}
+LATENCY_SUITE_FIXTURES = [
+    "chat-ok-ellipsis",
+    "technical-identifiers",
+    "structure-paragraph-breaks",
+    "long-form-single-sentence",
+]
+
+
+def peak_rss_bytes() -> int | None:
+    if resource is None:
+        return None
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return peak if sys.platform == "darwin" else peak * 1024
+
+
+def load_fixtures(corpus_path: Path, suite: str, fixture_id: str) -> list[dict[str, Any]]:
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    by_id = {fixture["id"]: fixture for fixture in corpus["cases"]}
+    fixture_ids = (
+        LATENCY_SUITE_FIXTURES
+        if suite == "latency"
+        else list(by_id)
+        if suite == "quality"
+        else [fixture_id]
+    )
+    missing = [item for item in fixture_ids if item not in by_id]
+    if missing:
+        raise ValueError(f"Unknown fixture(s): {', '.join(missing)}")
+    return [by_id[item] for item in fixture_ids]
+
+
+def percentile(values: list[float], percentile_value: float) -> float:
+    if not values:
+        raise ValueError("values must not be empty")
+    if not 0 <= percentile_value <= 100:
+        raise ValueError("percentile must be between 0 and 100")
+    ordered = sorted(values)
+    rank = max(1, math.ceil((percentile_value / 100) * len(ordered)))
+    return ordered[rank - 1]
+
+
+def summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    successful = [run for run in runs if "generationMs" in run]
+    if not successful:
+        return {
+            "successfulRuns": 0,
+            "failedRuns": len(runs),
+            "firstAudioMedianMs": None,
+            "firstAudioP95Ms": None,
+            "realTimeFactorMedian": None,
+            "averageCpuCoresMedian": None,
+        }
+    first_audio = [run["firstAudioMs"] for run in successful]
+    factors = [run["realTimeFactor"] for run in successful]
+    cpu_cores = [run["averageCpuCores"] for run in successful]
+    return {
+        "successfulRuns": len(successful),
+        "failedRuns": len(runs) - len(successful),
+        "firstAudioMedianMs": round(statistics.median(first_audio), 3),
+        "firstAudioP95Ms": round(percentile(first_audio, 95), 3),
+        "realTimeFactorMedian": round(statistics.median(factors), 4),
+        "averageCpuCoresMedian": round(statistics.median(cpu_cores), 3),
+    }
+
+
+def directory_size_bytes(directory: Path, names: set[str] | None = None) -> int:
+    total = 0
+    for path in directory.rglob("*"):
+        if path.is_file() and (names is None or path.name in names):
+            total += path.stat().st_size
+    return total
+
+
+def measure_call(
+    call: Callable[[], Any],
+    synchronize: Callable[[], None],
+) -> tuple[Any, float, float]:
+    synchronize()
+    wall_started = time.perf_counter()
+    cpu_started = time.process_time()
+    value = call()
+    synchronize()
+    wall_ms = (time.perf_counter() - wall_started) * 1000
+    cpu_ms = (time.process_time() - cpu_started) * 1000
+    return value, wall_ms, cpu_ms
+
+
+def benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    import numpy as np
+    import torch
+    import torchaudio
+    from chatterbox.tts_turbo import ChatterboxTurboTTS
+    from huggingface_hub import snapshot_download
+
+    fixtures = load_fixtures(args.corpus, args.suite, args.fixture)
+    if args.device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not available")
+    if args.device == "mps" and not torch.backends.mps.is_available():
+        raise RuntimeError("MPS was requested but is not available")
+
+    if args.model_dir:
+        model_dir = args.model_dir.resolve()
+    else:
+        model_dir = Path(
+            snapshot_download(
+                repo_id=MODEL_REPOSITORY,
+                revision=args.model_revision,
+                allow_patterns=OFFICIAL_DOWNLOAD_PATTERNS,
+                token=os.getenv("HF_TOKEN") or None,
+            )
+        )
+
+    missing_assets = sorted(name for name in NANO_RUNTIME_FILES if not (model_dir / name).is_file())
+    if missing_assets:
+        raise FileNotFoundError(f"Missing Nano runtime assets: {', '.join(missing_assets)}")
+
+    def synchronize() -> None:
+        if args.device == "cuda":
+            torch.cuda.synchronize()
+        elif args.device == "mps":
+            torch.mps.synchronize()
+
+    model, model_load_ms, model_load_cpu_ms = measure_call(
+        lambda: ChatterboxTurboTTS.from_local(model_dir, args.device, nano=True),
+        synchronize,
+    )
+    resident_device_bytes = None
+    if args.device == "mps":
+        resident_device_bytes = int(torch.mps.driver_allocated_memory())
+    elif args.device == "cuda":
+        resident_device_bytes = int(torch.cuda.memory_allocated())
+
+    def generate(text: str):
+        return model.generate(text)
+
+    def seed_generation(seed: int) -> None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+
+    for _ in range(args.warmup_runs):
+        seed_generation(args.seed)
+        measure_call(lambda: generate("Okay."), synchronize)
+
+    if args.audio_dir:
+        args.audio_dir.mkdir(parents=True, exist_ok=True)
+
+    runs: list[dict[str, Any]] = []
+    for repetition in range(args.repetitions):
+        for fixture in fixtures:
+            base = {
+                "run": repetition + 1,
+                "fixtureId": fixture["id"],
+                "textLength": len(fixture["input"]),
+                "wordCount": len(fixture["input"].split()),
+            }
+            try:
+                seed_generation(args.seed + repetition)
+                wav, generation_ms, cpu_ms = measure_call(
+                    lambda text=fixture["input"]: generate(text),
+                    synchronize,
+                )
+                sample_count = int(wav.shape[-1])
+                audio_duration_ms = sample_count / model.sr * 1000
+                result = {
+                    **base,
+                    # Official Nano returns one complete tensor, not a stream. The
+                    # full generation latency is therefore its earliest audio.
+                    "firstAudioMs": round(generation_ms, 3),
+                    "generationMs": round(generation_ms, 3),
+                    "cpuTimeMs": round(cpu_ms, 3),
+                    "averageCpuCores": round(cpu_ms / generation_ms, 3),
+                    "sampleCount": sample_count,
+                    "audioDurationMs": round(audio_duration_ms, 3),
+                    "realTimeFactor": round(generation_ms / audio_duration_ms, 4),
+                }
+                if args.audio_dir:
+                    filename = f"nano-{args.device}-{fixture['id']}-r{repetition + 1}.wav"
+                    torchaudio.save(str(args.audio_dir / filename), wav.cpu(), model.sr)
+                    result["audioFile"] = filename
+                runs.append(result)
+            except Exception as error:
+                runs.append({
+                    **base,
+                    "errorType": type(error).__name__,
+                    "error": str(error),
+                })
+
+    try:
+        chatterbox_version = importlib.metadata.version("chatterbox-tts")
+    except importlib.metadata.PackageNotFoundError:
+        chatterbox_version = "unknown"
+
+    return {
+        "schemaVersion": 1,
+        "benchmark": "chatterbox-nano-whole-utterance",
+        "recordedAtUnixMs": time.time_ns() // 1_000_000,
+        "implementation": {
+            "repository": "https://github.com/resemble-ai/chatterbox",
+            "revision": args.implementation_revision,
+            "packageVersion": chatterbox_version,
+            "class": "ChatterboxTurboTTS",
+            "nano": True,
+        },
+        "model": {
+            "repository": MODEL_REPOSITORY,
+            "revision": args.model_revision,
+            "officialSnapshotBytes": directory_size_bytes(model_dir),
+            "loadedRuntimeAssetBytes": directory_size_bytes(model_dir, NANO_RUNTIME_FILES),
+            "officialDownloadPatterns": OFFICIAL_DOWNLOAD_PATTERNS,
+        },
+        "environment": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "device": args.device,
+            "logicalCpuCount": os.cpu_count(),
+            "mpsAvailable": bool(torch.backends.mps.is_available()),
+            "cudaAvailable": bool(torch.cuda.is_available()),
+        },
+        "delivery": {
+            "apiMode": "whole-utterance",
+            "streamingChunks": False,
+            "firstAudioDefinition": "model.generate return; no earlier audio is exposed",
+        },
+        "fixtureSet": {
+            "corpusSchemaVersion": 1,
+            "suite": args.suite,
+            "fixtures": [
+                {
+                    "id": fixture["id"],
+                    "category": fixture["category"],
+                    "textLength": len(fixture["input"]),
+                    "wordCount": len(fixture["input"].split()),
+                }
+                for fixture in fixtures
+            ],
+        },
+        "settings": {
+            "seed": args.seed,
+            "warmupRuns": args.warmup_runs,
+            "repetitions": args.repetitions,
+        },
+        "startup": {
+            "modelLoadMs": round(model_load_ms, 3),
+            "modelLoadCpuMs": round(model_load_cpu_ms, 3),
+            "residentDeviceBytesAfterLoad": resident_device_bytes,
+        },
+        "summary": summarize_runs(runs),
+        "peakRssBytes": peak_rss_bytes(),
+        "runs": runs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", choices=["cpu", "mps", "cuda"], default="cpu")
+    parser.add_argument("--suite", choices=["single", "latency", "quality"], default="single")
+    parser.add_argument("--fixture", default="chat-ok-ellipsis")
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--model-dir", type=Path)
+    parser.add_argument("--model-revision", default=MODEL_REVISION)
+    parser.add_argument("--implementation-revision", default=IMPLEMENTATION_REVISION)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=27)
+    parser.add_argument("--audio-dir", type=Path)
+    parser.add_argument("--output", "-o", type=Path)
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    if args.repetitions < 1 or args.warmup_runs < 0:
+        parser.error("repetitions must be positive; warmup-runs cannot be negative")
+
+    try:
+        result = benchmark(args)
+    except Exception as error:
+        print(f"Benchmark failed: {error}", file=sys.stderr)
+        return 1
+    rendered = json.dumps(result, indent=2 if args.pretty else None, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_benchmark_chatterbox_nano.py
+++ b/scripts/test_benchmark_chatterbox_nano.py
@@ -1,0 +1,78 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from benchmark_chatterbox_nano import (
+    NANO_RUNTIME_FILES,
+    directory_size_bytes,
+    load_fixtures,
+    peak_rss_bytes,
+    percentile,
+    summarize_runs,
+)
+
+
+class ChatterboxNanoBenchmarkTests(unittest.TestCase):
+    def test_percentile_validates_bounds(self):
+        self.assertEqual(percentile([40, 10, 30, 20], 50), 20)
+        self.assertEqual(percentile([40, 10, 30, 20], 95), 40)
+        with self.assertRaises(ValueError):
+            percentile([], 95)
+        with self.assertRaises(ValueError):
+            percentile([1], 101)
+
+    def test_loads_single_latency_and_quality_suites(self):
+        with tempfile.TemporaryDirectory() as directory:
+            corpus_path = Path(directory) / "corpus.json"
+            cases = [
+                {"id": fixture_id, "category": "test", "input": fixture_id}
+                for fixture_id in [
+                    "chat-ok-ellipsis",
+                    "technical-identifiers",
+                    "structure-paragraph-breaks",
+                    "long-form-single-sentence",
+                    "extra",
+                ]
+            ]
+            corpus_path.write_text(json.dumps({"cases": cases}), encoding="utf-8")
+
+            self.assertEqual(load_fixtures(corpus_path, "single", "extra")[0]["id"], "extra")
+            self.assertEqual(len(load_fixtures(corpus_path, "latency", "extra")), 4)
+            self.assertEqual(len(load_fixtures(corpus_path, "quality", "extra")), 5)
+            with self.assertRaises(ValueError):
+                load_fixtures(corpus_path, "single", "missing")
+
+    def test_summarizes_whole_utterance_latency_and_failures(self):
+        summary = summarize_runs([
+            {"firstAudioMs": 100, "generationMs": 100, "realTimeFactor": 0.2, "averageCpuCores": 2.0},
+            {"firstAudioMs": 300, "generationMs": 300, "realTimeFactor": 0.6, "averageCpuCores": 1.0},
+            {"firstAudioMs": 200, "generationMs": 200, "realTimeFactor": 0.4, "averageCpuCores": 1.5},
+            {"error": "failed"},
+        ])
+
+        self.assertEqual(summary["successfulRuns"], 3)
+        self.assertEqual(summary["failedRuns"], 1)
+        self.assertEqual(summary["firstAudioMedianMs"], 200)
+        self.assertEqual(summary["firstAudioP95Ms"], 300)
+        self.assertEqual(summary["realTimeFactorMedian"], 0.4)
+        self.assertEqual(summary["averageCpuCoresMedian"], 1.5)
+
+    def test_counts_snapshot_and_loaded_runtime_assets_separately(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            runtime_name = next(iter(NANO_RUNTIME_FILES))
+            (root / runtime_name).write_bytes(b"runtime")
+            (root / "unused.safetensors").write_bytes(b"unused-large")
+
+            self.assertEqual(directory_size_bytes(root), 19)
+            self.assertEqual(directory_size_bytes(root, NANO_RUNTIME_FILES), 7)
+
+    def test_allows_peak_memory_metric_to_be_unavailable_on_windows(self):
+        with patch("benchmark_chatterbox_nano.resource", None):
+            self.assertIsNone(peak_rss_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a pinned, isolated Chatterbox Nano benchmark using the existing reader-quality corpus
- record first-audio/full-generation latency, RTF, CPU use, peak RSS, accelerator memory, and selected-vs-loaded model size
- document the Apple M2 results, app-control compatibility, license/privacy/watermark considerations, and explicit open gates
- record the evidence-gated product decision in the roadmap

## Result

The current official Nano v0.1.7 implementation does **not** pass the engine-pack gate on the available M2 reference machine:

- official loader snapshot: 2.79 GiB; actually loaded runtime assets: 1.81 GiB
- warmed short fixture: 13.02 s CPU / 10.50 s MPS median before any audio is exposed
- warmed RTF: 3.420 CPU / 2.915 MPS (slower than real time)
- peak RSS: 4.36 GB CPU / 3.68 GB MPS
- official API returns only a complete utterance and exposes no streaming/cancellation hook
- the raw long-form fixture hits the shared PyTorch MPS 65,536-output-channel limit

Kokoro remains bundled/default. This PR adds no Chatterbox app dependency, model download, engine selection UX, branding, installer change, or release change.

Intel Mac, Windows, frozen-pack, and blind-listening gates remain open and are not claimed as passing. Given the failed objective gates, the recommendation is to defer those expensive gates until upstream provides a materially smaller, streaming/cancellable release.

## Verification

- `python3 .codex/skills/kokoro-issue-to-release/scripts/verify.py`
  - 25 sidecar tests passed
  - 18 script tests passed
  - 64 frontend tests passed
  - frontend production build passed
  - Rust formatting passed
  - 4 Rust tests passed
- official Nano CPU and MPS benchmarks executed offline after the pinned snapshot was cached
- matched Kokoro CPU and MPS baselines executed against the same four fixture IDs

Closes #27