### PR TITLE
Prevent list and pause/resume audio artifacts

### DIFF
--- a/sidecar/audio_playback.py
+++ b/sidecar/audio_playback.py
@@ -40,6 +40,8 @@ def write_audio_blocks(
     should_interrupt: Callable[[], bool],
     before_write: Callable[[int, int], None] | None = None,
     after_write: Callable[[int, int], None] | None = None,
+    transform_write: Callable[[Any], Any] | None = None,
+    after_write_block: Callable[[Any], None] | None = None,
 ) -> BlockWriteResult:
     """Write audio sequentially and return the first unwritten sample offset.
 
@@ -61,8 +63,13 @@ def write_audio_blocks(
         if before_write is not None:
             before_write(offset, end_offset)
         start_offset_for_write = offset
-        stream.write(audio[offset:end_offset])
+        output_block = audio[offset:end_offset]
+        if transform_write is not None:
+            output_block = transform_write(output_block)
+        stream.write(output_block)
         offset = end_offset
+        if after_write_block is not None:
+            after_write_block(output_block)
         if after_write is not None:
             after_write(start_offset_for_write, end_offset)
 
@@ -81,6 +88,8 @@ def play_queued_audio(
     on_resumed: Callable[[Any], None] | None = None,
     process_audio_block: Callable[[Any], Any] | None = None,
     flush_audio: Callable[[], Any] | None = None,
+    pause_fade_audio: Callable[[Any], Any] | None = None,
+    fade_in_audio: Callable[[Any], Any] | None = None,
     source_block_size: int = 480,
     queue_timeout: float = 0.05,
 ) -> QueuePlaybackResult:
@@ -103,13 +112,44 @@ def play_queued_audio(
     end_received = False
     completed_chunks = 0
     playback_started = False
+    last_output_sample = None
+    resume_fade_pending = False
     stream.start()
+
+    def transform_output(block):
+        nonlocal resume_fade_pending
+        if resume_fade_pending and fade_in_audio is not None:
+            block = fade_in_audio(block)
+            resume_fade_pending = False
+        return block
+
+    def remember_output(block):
+        nonlocal last_output_sample
+        if len(block) == 0:
+            return
+        last_output_sample = block[-1]
+        if hasattr(last_output_sample, "copy"):
+            last_output_sample = last_output_sample.copy()
+
+    def pause_stream():
+        nonlocal resume_fade_pending
+        first_acknowledgement = session.acknowledge_pause()
+        if first_acknowledgement:
+            if pause_fade_audio is not None and last_output_sample is not None:
+                fade = pause_fade_audio(last_output_sample)
+                if len(fade) > 0:
+                    stream.write(fade)
+            if stream.active:
+                stream.stop()
+            resume_fade_pending = True
+            if on_paused is not None:
+                on_paused(session.position())
+        elif stream.active:
+            stream.stop()
 
     while not session.cancel_event.is_set():
         if session.pause_event.is_set():
-            stream.stop()
-            if session.acknowledge_pause() and on_paused is not None:
-                on_paused(session.position())
+            pause_stream()
             session.cancel_event.wait(0.01)
             continue
 
@@ -135,13 +175,13 @@ def play_queued_audio(
                     session.cancel_event.is_set() or session.pause_event.is_set()
                 ),
                 after_write=after_write,
+                transform_write=transform_output,
+                after_write_block=remember_output,
             )
             pending_offset = result.next_offset
             if not result.completed:
                 if session.pause_event.is_set():
-                    stream.stop()
-                    if session.acknowledge_pause() and on_paused is not None:
-                        on_paused(session.position())
+                    pause_stream()
                 continue
             pending_audio = None
             pending_offset = 0
@@ -197,15 +237,15 @@ def play_queued_audio(
                 session.cancel_event.is_set() or session.pause_event.is_set()
             ),
             after_write=after_write,
+            transform_write=transform_output,
+            after_write_block=remember_output,
         )
         current_offset = result.next_offset
         session.set_position(current_chunk.index, current_offset)
 
         if not result.completed:
             if session.pause_event.is_set():
-                stream.stop()
-                if session.acknowledge_pause() and on_paused is not None:
-                    on_paused(session.position())
+                pause_stream()
             continue
 
         audio_queue.task_done()

--- a/sidecar/audio_safety.py
+++ b/sidecar/audio_safety.py
@@ -1,0 +1,49 @@
+"""Waveform safety helpers for device-output boundaries."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+DEFAULT_FADE_SAMPLES = 120  # 5 ms at the app's 24 kHz output rate.
+
+
+def sanitize_audio_buffer(audio) -> np.ndarray:
+    """Return finite, clipped float32 mono audio safe for device output."""
+
+    result = np.asarray(audio, dtype=np.float32)
+    if result.ndim == 1:
+        result = result.reshape(-1, 1)
+    elif result.ndim != 2 or result.shape[1] != 1:
+        raise ValueError("audio output must be mono")
+    result = np.nan_to_num(result, nan=0.0, posinf=1.0, neginf=-1.0)
+    return np.clip(result, -1.0, 1.0).astype(np.float32, copy=False)
+
+
+def fade_to_silence(
+    last_sample,
+    sample_count: int = DEFAULT_FADE_SAMPLES,
+) -> np.ndarray:
+    """Create a short ramp from the current device sample to digital silence."""
+
+    if sample_count <= 0:
+        raise ValueError("sample_count must be positive")
+    sample = np.asarray(last_sample, dtype=np.float32).reshape(1, -1)
+    gains = np.linspace(1.0, 0.0, sample_count, dtype=np.float32).reshape(-1, 1)
+    return sanitize_audio_buffer(gains * sample)
+
+
+def fade_from_silence(
+    audio,
+    sample_count: int = DEFAULT_FADE_SAMPLES,
+) -> np.ndarray:
+    """Ramp the first output samples up from zero without mutating the input."""
+
+    if sample_count <= 0:
+        raise ValueError("sample_count must be positive")
+    result = sanitize_audio_buffer(audio).copy()
+    fade_length = min(sample_count, len(result))
+    if fade_length:
+        gains = np.linspace(0.0, 1.0, fade_length, dtype=np.float32).reshape(-1, 1)
+        result[:fade_length] *= gains
+    return result

--- a/sidecar/kokoro_server.py
+++ b/sidecar/kokoro_server.py
@@ -9,6 +9,11 @@ from flask import Flask, request, jsonify
 try:
     from .tts_protocol import encode_tts_event, normalize_synthesis_segments
     from .audio_playback import AudioChunk, play_queued_audio
+    from .audio_safety import (
+        fade_from_silence,
+        fade_to_silence,
+        sanitize_audio_buffer,
+    )
     from .playback_session import PlaybackSessionController
     from .pipeline_loader import create_offline_pipeline
     from .sonic_speed import SonicSpeedProcessor
@@ -16,6 +21,7 @@ except ImportError:
     # Script/PyInstaller execution places the sidecar directory on sys.path.
     from tts_protocol import encode_tts_event, normalize_synthesis_segments
     from audio_playback import AudioChunk, play_queued_audio
+    from audio_safety import fade_from_silence, fade_to_silence, sanitize_audio_buffer
     from playback_session import PlaybackSessionController
     from pipeline_loader import create_offline_pipeline
     from sonic_speed import SonicSpeedProcessor
@@ -345,6 +351,9 @@ def tts():
             if len(played_audio.shape) == 1:
                 played_audio = played_audio.reshape(-1, 1)
 
+            # Keep invalid or over-range model samples away from the audio device.
+            played_audio = sanitize_audio_buffer(played_audio)
+
             pause_sample_count = int(24000 * chunk.pause_after_ms / 1000)
             if pause_sample_count:
                 played_audio = np.concatenate([
@@ -377,7 +386,7 @@ def tts():
                     chunkIndex=position.chunk_index,
                     sampleOffset=position.sample_offset,
                 )
-            return processed
+            return sanitize_audio_buffer(processed)
         
         try:
             # Open a persistent stream for the entire session
@@ -398,7 +407,9 @@ def tts():
                     on_paused=lambda position: emit_control_acknowledgement("paused", position),
                     on_resumed=lambda position: emit_control_acknowledgement("resumed", position),
                     process_audio_block=lambda audio: process_speed_block(speed_processor, audio),
-                    flush_audio=speed_processor.flush,
+                    flush_audio=lambda: sanitize_audio_buffer(speed_processor.flush()),
+                    pause_fade_audio=fade_to_silence,
+                    fade_in_audio=fade_from_silence,
                     source_block_size=480,
                 )
         except Exception as e:

--- a/sidecar/test_audio_playback.py
+++ b/sidecar/test_audio_playback.py
@@ -196,6 +196,40 @@ class AudioPlaybackTests(unittest.TestCase):
             list(range(12)),
         )
 
+    def test_queue_player_smooths_pause_and_resume_boundaries(self):
+        audio_queue = Queue()
+        audio_queue.put(AudioChunk(0, [0.8, 0.6, -0.5, -0.7], 0, "segment-0"))
+        audio_queue.put(None)
+        session = PlaybackSessionController().begin("smooth-request")
+
+        def pause_after_first_block(stream):
+            if len(stream.blocks) == 1:
+                session.pause()
+
+        stream = FakePersistentStream(after_write=pause_after_first_block)
+
+        def resume_after_ack(_position):
+            session.resume()
+
+        play_queued_audio(
+            stream,
+            audio_queue,
+            session,
+            prepare_audio=lambda chunk: chunk.audio,
+            block_size=2,
+            on_paused=resume_after_ack,
+            pause_fade_audio=lambda last_sample: [last_sample, last_sample / 2, 0.0],
+            fade_in_audio=lambda block: [0.0, block[-1]],
+        )
+
+        self.assertEqual(stream.stop_count, 1)
+        self.assertEqual(stream.start_count, 2)
+        self.assertEqual(stream.blocks, [
+            [0.8, 0.6],
+            [0.6, 0.3, 0.0],
+            [0.0, -0.7],
+        ])
+
     def test_queue_player_cancels_without_writing_future_chunks(self):
         audio_queue = Queue()
         audio_queue.put(AudioChunk(0, list(range(8)), 0, "segment-0"))

--- a/sidecar/test_audio_safety.py
+++ b/sidecar/test_audio_safety.py
@@ -1,0 +1,45 @@
+import unittest
+
+import numpy as np
+
+from sidecar.audio_safety import (
+    fade_from_silence,
+    fade_to_silence,
+    sanitize_audio_buffer,
+)
+
+
+class AudioSafetyTests(unittest.TestCase):
+    def test_sanitizes_non_finite_and_out_of_range_samples(self):
+        audio = np.array([np.nan, np.inf, -np.inf, 1.8, -2.1, 0.25])
+
+        result = sanitize_audio_buffer(audio)
+
+        self.assertEqual(result.dtype, np.float32)
+        self.assertEqual(result.shape, (6, 1))
+        np.testing.assert_allclose(
+            result[:, 0],
+            [0.0, 1.0, -1.0, 1.0, -1.0, 0.25],
+        )
+
+    def test_pause_fade_reaches_zero_without_exceeding_last_sample(self):
+        result = fade_to_silence(np.array([0.8], dtype=np.float32), sample_count=5)
+
+        self.assertEqual(result.shape, (5, 1))
+        self.assertAlmostEqual(float(result[0, 0]), 0.8)
+        self.assertAlmostEqual(float(result[-1, 0]), 0.0)
+        self.assertTrue(np.all(np.diff(result[:, 0]) <= 0))
+
+    def test_resume_fade_starts_at_zero_and_preserves_the_tail(self):
+        audio = np.ones((8, 1), dtype=np.float32)
+
+        result = fade_from_silence(audio, sample_count=4)
+
+        self.assertAlmostEqual(float(result[0, 0]), 0.0)
+        self.assertAlmostEqual(float(result[3, 0]), 1.0)
+        np.testing.assert_allclose(result[4:, 0], np.ones(4))
+        np.testing.assert_allclose(audio[:, 0], np.ones(8))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/speechPlanner.test.ts
+++ b/src/utils/speechPlanner.test.ts
@@ -45,6 +45,23 @@ describe("speech planner", () => {
     ]);
   });
 
+  it("strips Unicode and Markdown bullets before text reaches Kokoro", () => {
+    const input = [
+      "• Sync status (done)",
+      "* Merged origin/development into the branch.",
+      "- Branch tip includes the merge commit.",
+    ].join("\n");
+
+    const segments = planTextForTTS(input);
+
+    expect(segments.map(({ kind, spokenText }) => ({ kind, spokenText }))).toEqual([
+      { kind: "list-item", spokenText: "Sync status (done)" },
+      { kind: "list-item", spokenText: "Merged origin/development into the branch." },
+      { kind: "list-item", spokenText: "Branch tip includes the merge commit." },
+    ]);
+    expect(segments.every((segment) => !/[•*]/.test(segment.spokenText))).toBe(true);
+  });
+
   it("infers a high-confidence heading when plain clipboard text retains only a line break", () => {
     const segments = planTextForTTS(
       "Why this matters\nThe listener needs a brief pause before this explanation begins.",

--- a/src/utils/speechPlanner.ts
+++ b/src/utils/speechPlanner.ts
@@ -48,6 +48,8 @@ type SpeechBlock = {
   stripPrefix?: RegExp;
 };
 
+const LIST_ITEM_PREFIX = /^\s*(?:[-*+•‣◦]|\d+[.)])\s+/;
+
 const FINAL_PAUSE_MS: Record<SpeechBlock["kind"], number> = {
   heading: 550,
   paragraph: 420,
@@ -126,7 +128,7 @@ function isHeading(line: SourceLine): boolean {
 }
 
 function isListItem(line: SourceLine): boolean {
-  return /^\s*(?:[-*+]|\d+[.)])\s+/.test(line.text);
+  return LIST_ITEM_PREFIX.test(line.text);
 }
 
 function isQuote(line: SourceLine): boolean {
@@ -206,7 +208,7 @@ function parseBlocks(input: string): SpeechBlock[] {
       blocks.push({
         kind: "list-item",
         lines: [line],
-        stripPrefix: /^\s*(?:[-*+]|\d+[.)])\s+/,
+        stripPrefix: LIST_ITEM_PREFIX,
       });
       index += 1;
       continue;

--- a/src/utils/textCleaner.test.ts
+++ b/src/utils/textCleaner.test.ts
@@ -58,8 +58,8 @@ describe("cleanTextForTTS", () => {
 
   // ── Lists ─────────────────────────────────────────────────────────────────
   it("strips unordered list bullets", () => {
-    const input = "- Item one\n- Item two\n* Item three";
-    expect(cleanTextForTTS(input)).toBe("Item one Item two Item three");
+    const input = "- Item one\n- Item two\n* Item three\n• Item four";
+    expect(cleanTextForTTS(input)).toBe("Item one Item two Item three Item four");
   });
 
   it("strips ordered list numbers", () => {

--- a/src/utils/textCleaner.ts
+++ b/src/utils/textCleaner.ts
@@ -34,8 +34,8 @@ export function cleanTextForTTS(input: string): string {
   // Remove horizontal rules (---, ***, ___)
   text = text.replace(/^[\s]*([-*_]){3,}\s*$/gm, "");
 
-  // Remove unordered list bullets (- , * , + )
-  text = text.replace(/^\s*[-*+]\s+/gm, "");
+  // Remove Markdown and common rich-text list bullets.
+  text = text.replace(/^\s*[-*+•‣◦]\s+/gm, "");
 
   // Remove ordered list numbers (1. , 2. , etc.)
   text = text.replace(/^\s*\d+\.\s+/gm, "");


### PR DESCRIPTION
## What changed

- strip Unicode rich-text bullets (`•`, `‣`, `◦`) alongside Markdown list markers before text reaches Kokoro
- clamp non-finite and over-range samples before device output
- add a 5 ms ramp to silence before pausing and a 5 ms ramp up after resuming
- preserve the exact first-unwritten source offset and existing live-speed processing
- add planner, waveform-safety, and pause/resume state-machine regressions

## Root cause

The speech planner recognized ASCII Markdown bullets but not common Unicode bullets, allowing a non-speech symbol to reach Kokoro and influence list-start prosody. Separately, pause stopped the persistent output stream at an arbitrary waveform value and resume restarted at another arbitrary value, creating a discontinuity that can be heard as a click/pop. The output path also did not explicitly sanitize non-finite or over-range samples.

## Validation

- 29 sidecar tests pass
- 13 script tests pass
- 65 frontend tests pass
- production frontend build passes
- Rust formatting and 4 Rust tests pass
- `git diff --check` passes

## Manual gate and merge order

- Windows speaker/headphone repetition testing is still required for the reported hardware transient and the supplied clipboard sample.
- This PR intentionally uses `Refs #32` rather than closing the issue until that manual gate passes.
- Per product sequencing, issue/PR #27 must land before this PR is merged.

Refs #32